### PR TITLE
Update error handling and handled partials

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,16 +1,26 @@
 var es    = require('event-stream')
   , clone = require('clone')
   , sass  = require('node-sass')
-  , ext   = require('gulp-util').replaceExtension
+  , path  = require('path')
+  , gutil = require('gulp-util')
+  , ext   = gutil.replaceExtension
   ;
 
 module.exports = function (options) {
   var opts = options ? clone(options) : {};
 
   function nodeSass (file, cb) {
+    // file is on object passed in by gulp
+    // file.contents is always a Buffer
+
+    if (path.basename(file.path).indexOf('_') === 0) {
+      //gutil.log('[gulp-sass] Partial: ' + path.basename(file.path) + ' ignored');
+      return cb();
+    }
 
     if (file.isNull()) {
-      return cb(null, file);
+      gutil.log('[gulp-sass] Empty file: ' + path.basename(file.path) + ' ignored');
+      return cb();
     }
 
     opts.data = file.contents.toString();
@@ -19,12 +29,13 @@ module.exports = function (options) {
       file.path      = ext(file.path, '.css');
       file.shortened = file.shortened && ext(file.shortened, '.css');
       file.contents  = new Buffer(css);
-
       cb(null, file);
     }
 
     opts.error = function (err) {
-      cb(err);
+      //return cb(new gutil.PluginError('gulp-imagemin', err));
+      gutil.log('[gulp-sass] Error: ' + err);
+      return cb();
     }
 
     sass.render(opts);


### PR DESCRIPTION
1. Updated so as an error is logged rather than reported as an error as this will stop the watcher which could be annoying - although may be a preference option?
2. Added logic to ignore a partial (doesn't log) essentially a sass file prefixed with '_'
