### PR TITLE
Remove clone

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,5 +1,4 @@
 var map    = require('map-stream')
-  , clone = require('clone')
   , sass  = require('node-sass')
   , path  = require('path')
   , gutil = require('gulp-util')

--- a/package.json
+++ b/package.json
@@ -21,7 +21,6 @@
     "url": "https://github.com/dlmanning/gulp-sass/issues"
   },
   "dependencies": {
-    "clone": "~0.1.10",
     "node-sass": "~0.7.0",
     "gulp-util": "~2.2.5",
     "map-stream": "~0.1.0"


### PR DESCRIPTION
Remove clone, replace event-stream with map-stream (reduces dependencies)
Remove the file.path _ check, this should be managed with gulp.src.
