### PR TITLE
Make libsass output valid source map json by making all paths relative...

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,6 +3,7 @@ var fs    = require('fs')
   , sass  = require('node-sass')
   , path  = require('path')
   , gutil = require('gulp-util')
+  , slash = require('slash')
   , ext   = gutil.replaceExtension
   ;
 
@@ -21,7 +22,8 @@ module.exports = function (options) {
     }
 
     if (opts.sourceComments === 'map' || opts.sourceComments === 'normal') {
-      opts.file = file.path;
+      opts.file = getCorrectRelativePath(file);
+      fileDir = path.dirname(getCorrectRelativePath(file));
     } else {
       opts.data = file.contents.toString();
     }
@@ -84,4 +86,14 @@ function getSourcesContent (sources) {
   }
 
   return sourcesContent;
+}
+
+function getCorrectRelativePath (file) {
+  var relativeFile = path.relative(file.cwd, file.path);
+
+  if (process.platform === 'win32') {
+    relativeFile = slash(relativeFile);
+  }
+
+  return relativeFile;
 }

--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "node-sass": "~0.8",
     "gulp-util": "~2.2",
-    "map-stream": "~0.1"
+    "map-stream": "~0.1",
+    "slash": "^0.1.1"
   },
   "devDependencies": {
     "tape": "~2.3",


### PR DESCRIPTION
...and fixing the slashes in these paths on win32 only

If you want source maps to work on Windows, then libsass seems to require that the inputs be relative paths using unix path separators.