### PR TITLE
More comprehensive error output

### DIFF
--- a/index.js
+++ b/index.js
@@ -64,6 +64,8 @@ module.exports = function (options) {
         return cb();
       }
 
+      err = parseError(err);
+
       return cb(new gutil.PluginError('gulp-sass', err));
     };
 
@@ -84,4 +86,21 @@ function getSourcesContent (sources) {
   }
 
   return sourcesContent;
+}
+
+/**
+ * Parse error output from node-sass and extract file
+ * line number and error message
+ * @param  {string} err Error output form node sass
+ * @return {object}     Gulp error object
+ */
+function parseError (err) {
+  var regex = /^.+(?:\/|\\)(.+):(\d+): error: (.+)\n/;
+  var result = err.match(regex);
+  return {
+    fileName: result[1],
+    showStack: false,
+    lineNumber: parseInt(result[2], 10),
+    message: result[3]
+  }
 }


### PR DESCRIPTION
The error output from this plugin was not really formatted very well: 
```JavaScript
{ plugin: 'gulp-sass',
  showStack: undefined,
  name: 'Error',
  message: 'sources/scss/forms:20: error: error reading values after display\n',
  fileName: undefined,
  lineNumber: undefined }
```
The function that I added transforms it into
```Javascript
{ plugin: 'gulp-sass',
  showStack: false,
  name: 'Error',
  message: 'error reading values after display',
  fileName: 'forms', 
  lineNumber: 16}
```

I understand this is not really an issue that is caused by this plugin. But fixing this problem would involve adding JSON error output from node-sass.

I do not think what I made is finished or stable. But at least we can discuss the issue here.