### PR TITLE
Update node-sass dependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,7 +21,7 @@
     "url": "https://github.com/dlmanning/gulp-sass/issues"
   },
   "dependencies": {
-    "node-sass": "~0.8",
+    "node-sass": "~0.9",
     "gulp-util": "~2.2",
     "map-stream": "~0.1"
   },


### PR DESCRIPTION
Updating to libsass 2.0. Closes https://github.com/dlmanning/gulp-sass/issues/53, https://github.com/dlmanning/gulp-sass/issues/55.
