### PR TITLE
feat(index.js): change map-stream to through2

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,9 +21,9 @@
     "url": "https://github.com/dlmanning/gulp-sass/issues"
   },
   "dependencies": {
-    "node-sass": "^0.9",
     "gulp-util": "^3.0",
-    "map-stream": "~0.1",
+    "node-sass": "^0.9",
+    "through2": "^0.5.1",
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This will make the error handling of streams more consistent with latest standards.

Please also take a look at the comment :
https://github.com/tomchentw/gulp-sass/blob/1088882529b11ffd0f34d76d0f757d66d0376571/index.js#L67
