### PR TITLE
Consistent file handling

### DIFF
--- a/index.js
+++ b/index.js
@@ -20,11 +20,7 @@ module.exports = function (options) {
       return cb();
     }
 
-    if (opts.sourceComments === 'map' || opts.sourceComments === 'normal') {
-      opts.file = file.path;
-    } else {
-      opts.data = file.contents.toString();
-    }
+    opts.file = file.path;
 
     if (opts.includePaths && Array.isArray(opts.includePaths)) {
       if (opts.includePaths.indexOf(fileDir) === -1) {

--- a/test/scss/error.scss
+++ b/test/scss/error.scss
@@ -1,0 +1,1 @@
+body { font 'Comic Sans'; }

--- a/test/test.js
+++ b/test/test.js
@@ -17,6 +17,10 @@ function createVinyl(sassFileName, contents) {
   });
 }
 
+function contains(str, search) {
+  return str.indexOf(search) > -1;
+}
+
 test('pass file when isNull()', function (t) {
   var stream = gsass();
   var emptyFile = {
@@ -83,12 +87,11 @@ test('compile multiple sass files', function (t) {
 
 test('emit error on sass errors', function (t) {
   var stream = gsass();
-  var errorFile = createVinyl('somefile.sass',
-    new Buffer('body { font \'Comic Sans\'; }'));
+  var errorFile = createVinyl('error.scss');
   stream.on('error', function (err) {
-    t.equal(err.message,
-            'source string:1: error: property "font" must be followed by a \':\'\n'
-    );
+    t.ok(contains(err.message,
+            'error: property "font" must be followed by a \':\'\n'
+    ), 'correct error message is thrown.');
     t.end();
   });
   stream.write(errorFile);
@@ -96,14 +99,13 @@ test('emit error on sass errors', function (t) {
 
 test('call custom error callback when opts.onError is given', function (t) {
   var stream = gsass({ onError: function (err) {
-    t.equal(err,
-            'source string:1: error: property "font" must be followed by a \':\'\n'
-    );
+    t.ok(contains(err,
+            'error: property "font" must be followed by a \':\'\n'
+    ), 'correct error message is thrown.');
     t.end();
   }});
 
-  var errorFile = createVinyl('somefile.sass',
-    new Buffer('body { font \'Comic Sans\'; }'));
+  var errorFile = createVinyl('error.scss');
 
   stream.write(errorFile);
 });


### PR DESCRIPTION
Currently the file handling is different depending of the `sourceComments` option.

- when sourceComments is `map` or `normal` it use `file.path` as parameter
- on all other cases it set `opts.data` to be the stringified file.

This make the `.sass` indented files to not compile with the default parameters. node-sass or libsass need to know the extension to properly compile sass file which is not the case with the stringified content.

With the first commit only there was 2 tests failing. I think it was caused by the fact that these 2 tests where the only one with no real files (the error was that the file was not found).

Let me know if I can make anything to make this pull request happen. 