### PR TITLE
Update README

### DIFF
--- a/README.md
+++ b/README.md
@@ -1,9 +1,9 @@
-[![Build Status](https://travis-ci.org/dlmanning/gulp-sass.png?branch=master)](https://travis-ci.org/dlmanning/gulp-sass)
+[![Build Status](https://travis-ci.org/dlmanning/gulp-sass.svg?branch=master)](https://travis-ci.org/dlmanning/gulp-sass)
 
 gulp-sass
 =========
 
-SASS plugin for [gulp](https://github.com/wearefractal/gulp).
+SASS plugin for [gulp](https://github.com/gulpjs/gulp).
 
 #Install
 
@@ -26,7 +26,7 @@ gulp.task('sass', function () {
 });
 ```
 
-Options passed as a hash into `sass()` will be passed along to [`node-sass`](https://github.com/andrew/node-sass)
+Options passed as a hash into `sass()` will be passed along to [`node-sass`](https://github.com/sass/node-sass)
 
 ## gulp-sass specific options
 


### PR DESCRIPTION
- I changed the image format of the badge from PNG to SVG. SVG badges look beautiful on retina displays.
- I updated the URL of [gulp](https://github.com/gulpjs/gulp) and [node-sass](https://github.com/sass/node-sass). Even if Github automatically redirects old repository URL to new one, it is prefered that URL shows the latest location correctly.
