### PR TITLE
Option to write errors into the css file

### DIFF
--- a/README.md
+++ b/README.md
@@ -34,6 +34,10 @@ Options passed as a hash into `sass()` will be passed along to [`node-sass`](htt
 
 If you pass `errLogToConsole: true` into the options hash, sass errors will be logged to the console instead of generating a `gutil.PluginError` object. Use this option with `gulp.watch` to keep gulp from stopping every time you mess up your sass.
 
+#### `errLogToOutputFile: true`
+
+If you pass `errLogToOutputFile: true` into the options hash, sass errors will be written into the output css file. It keeps gulp from stopping.
+
 #### `onSuccess: callback`
 
 Pass in your own callback to be called upon successful compilaton by node-sass. The callback has the form `callback(css)`, and is passed the compiled css as a string. Note: This *does not* prevent gulp-sass's default behavior of writing the output css file.

--- a/index.js
+++ b/index.js
@@ -56,6 +56,14 @@ module.exports = function (options) {
     };
 
     opts.error = function (err) {
+
+      if (opts.errLogToOutputFile) {
+        var errFilePath = file.path;
+        file.path      = ext(file.path, '.css');
+        file.contents  = new Buffer('ERR: ' + errFilePath + '\n' + err.toString());
+        return cb(null, file);
+      }
+
       if (opts.errLogToConsole) {
         gutil.log('[gulp-sass] ' + err);
         return cb();


### PR DESCRIPTION
New option to directly write errors into the css file, as tools like assetic already do.
This way css guy can debug easily without having access to the gulp watch output (hidden in a vagrant daemon logs in my case)