### PR TITLE
feat(sourcemaps): provide option for writing out external sourcemaps

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,8 @@
   "dependencies": {
     "node-sass": "^0.9",
     "gulp-util": "~2.2",
-    "map-stream": "~0.1"
+    "map-stream": "~0.1",
+    "mkdirp": "~0.5.0"
   },
   "devDependencies": {
     "tape": "~2.3",


### PR DESCRIPTION
This PR introduces a new `sourceMapDest` configuration option for gulp-sass. If a sourcemap has been produced, and this option is specified, gulp-sass will synchronously write the sourcemap contents to a file stream and updating the CSS content stream with a path-less reference (since gulp stream destination is ultimately unknown).

This might not be ideal for everyone, but it unlocks functionality that is useful in a variety of situations.
