### PR TITLE
fix(sourcemaps): allow for rewriting sourceMappingURL in compressed output

### DIFF
--- a/index.js
+++ b/index.js
@@ -48,7 +48,7 @@ module.exports = function (options) {
 
       if (map) {
         // hack to remove the already added sourceMappingURL from libsass
-        css = css.replace(/\n\/\*#\s*sourceMappingURL\=.*\*\//, '');
+        css = css.replace(/\/\*#\s*sourceMappingURL\=.*\*\//, '');
 
         applySourceMap(file, map);
       }


### PR DESCRIPTION
This PR allows for external sourcemap support while using the `compressed` output style. libsass does not add a newline prior to outputting the `sourceMappingURL` in this mode. Previously, the regexp would fail due to specificity and would result in two `sourceMappingURL` entries. The incorrect (first) one would then be parsed by downtstream processors, breaking sourcemaps.
