### PR TITLE
Error in example

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ gulp.src('./scss/*.scss')
   .pipe(sourcemaps.init())
     .pipe(sass())
   .pipe(sourcemaps.write())
-  .pipe('./css');
+  .pipe(gulp.dest('./css'));
 
 // will write the source maps inline in the compiled CSS files
 ```
@@ -71,7 +71,7 @@ gulp.src('./scss/*.scss')
   .pipe(sourcemaps.init())
     .pipe(sass())
   .pipe(sourcemaps.write('./maps'))
-  .pipe('./css');
+  .pipe(gulp.dest('./css'));
 
 // will write the source maps to ./dest/css/maps
 ```


### PR DESCRIPTION
There was missing gulp.dest() around destination paths in 2 of the examples. Was causing non-logical errors.