### PR TITLE
Ensure opts.includePaths exists before calling a method on it.

### DIFF
--- a/index.js
+++ b/index.js
@@ -92,7 +92,7 @@ module.exports = function (options) {
 	  sass.render(opts);
 	}
 
-    if (addedLocalDirPath) opts.includePaths.pop();
+    if (addedLocalDirPath && opts.includePaths) opts.includePaths.pop();
 
   }
 


### PR DESCRIPTION
The opts.includePaths can be null here, so we need to be sure they exist.