### PR TITLE
Clone the options hash to prevent "opts.includePaths is undefined" errors

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,16 +3,16 @@ var fs    = require('fs')
   , sass  = require('node-sass')
   , path  = require('path')
   , gutil = require('gulp-util')
+  , clone = require('clone')
   , ext   = gutil.replaceExtension
   , applySourceMap = require('vinyl-sourcemaps-apply')
   ;
 
 module.exports = function (options) {
-  var opts = options || {};
+  var opts = options ? clone(options) : {};
 
   function nodeSass (file, cb) {
     var fileDir = path.dirname(file.path);
-    var addedLocalDirPath = false;
 
     if (file.isNull()) {
       return cb(null, file);
@@ -36,7 +36,6 @@ module.exports = function (options) {
     if (opts.includePaths && Array.isArray(opts.includePaths)) {
       if (opts.includePaths.indexOf(fileDir) === -1) {
         opts.includePaths.push(fileDir);
-        addedLocalDirPath = true;
       }
     } else {
       opts.includePaths = [fileDir];
@@ -91,8 +90,6 @@ module.exports = function (options) {
 	} else {
 	  sass.render(opts);
 	}
-
-    if (addedLocalDirPath) opts.includePaths.pop();
 
   }
 

--- a/package.json
+++ b/package.json
@@ -24,7 +24,8 @@
     "node-sass": "^1.0",
     "gulp-util": "^3.0",
     "map-stream": "~0.1",
-    "vinyl-sourcemaps-apply": "~0.1.1"
+    "vinyl-sourcemaps-apply": "~0.1.1",
+    "clone": "~0.1.18"
   },
   "devDependencies": {
     "tape": "~2.3",


### PR DESCRIPTION
Referring to #126, #125. Implemented the deep clone of the options hash at the prolog.
