### PR TITLE
Fix bug with includePaths

### DIFF
--- a/README.md
+++ b/README.md
@@ -105,3 +105,6 @@ scss/style.scss:
 }
 ```
 
+#Issues
+
+Before submitting an issue, please understand that gulp-sass is only a wrapper for [node-sass](https://github.com/sass/node-sass), which in turn is a node front end for [libsass](https://github.com/sass/libsass). Missing sass features and errors should not be reported here.

--- a/index.js
+++ b/index.js
@@ -102,7 +102,7 @@ module.exports = function (options) {
 	  sass.render(opts);
 	}
 
-    if (addedLocalDirPath) opts.includePaths.pop();
+    if (addedLocalDirPath && opts.includePaths) opts.includePaths.pop();
 
   }
 

--- a/index.js
+++ b/index.js
@@ -8,7 +8,8 @@ var fs    = require('fs')
   ;
 
 module.exports = function (options) {
-  var opts = options || {};
+  var opts = options || {},
+      collectedIncludePaths = [];
 
   function nodeSass (file, cb) {
     var fileDir = path.dirname(file.path);
@@ -38,6 +39,14 @@ module.exports = function (options) {
         opts.includePaths.push(fileDir);
         addedLocalDirPath = true;
       }
+
+      // collect all includes paths for future reference
+      opts.includePaths.forEach(function(path) {
+        if (collectedIncludePaths.indexOf(path) === -1) {
+          collectedIncludePaths.push(path);
+        }
+      });
+
     } else {
       opts.includePaths = [fileDir];
     }
@@ -89,6 +98,7 @@ module.exports = function (options) {
 	    opts.error(err);
 	  }
 	} else {
+    opts.includePaths = collectedIncludePaths;
 	  sass.render(opts);
 	}
 

--- a/index.js
+++ b/index.js
@@ -51,7 +51,7 @@ module.exports = function (options) {
       opts.includePaths = [fileDir];
     }
 
-		opts.includePath = opts.includePaths;
+    opts.includePath = opts.includePaths;
 
     opts.success = function (css, sourceMap) {
       if (typeof opts.onSuccess === 'function') opts.onSuccess(css, sourceMap);
@@ -89,18 +89,18 @@ module.exports = function (options) {
       return cb(new gutil.PluginError('gulp-sass', err));
     };
 
-	if ( opts.sync ) {
-	  try {
-	    var output = sass.renderSync(opts);
-	    opts.success(output, null);
-	    handleOutput(output, file, cb);
-	  } catch(err) {
-	    opts.error(err);
-	  }
-	} else {
-    opts.includePaths = collectedIncludePaths;
-	  sass.render(opts);
-	}
+    if ( opts.sync ) {
+      try {
+        var output = sass.renderSync(opts);
+        opts.success(output, null);
+        handleOutput(output, file, cb);
+      } catch(err) {
+        opts.error(err);
+      }
+    } else {
+      opts.includePaths = collectedIncludePaths;
+      sass.render(opts);
+    }
 
     if (addedLocalDirPath && opts.includePaths) opts.includePaths.pop();
 


### PR DESCRIPTION
### problem
The value of `opts.includePaths` was somehow lost between files in the stream.

### fix
Create an array called `collectedIncludePaths` that retains all values of `opts.includePaths` that pass through the stream. The `collectedIncludePaths` is passed to node-sass as the `includePaths` value.

### etc.
The indentation was off so I normalized the file to use spaces. Let me know if this makes the PR too hard to read and I'll submit one that retains the original indentation.