### PR TITLE
Add missing gulp.dest to README

### DIFF
--- a/README.md
+++ b/README.md
@@ -57,7 +57,7 @@ gulp.src('./scss/*.scss')
   .pipe(sourcemaps.init())
     .pipe(sass())
   .pipe(sourcemaps.write())
-  .pipe('./css');
+  .pipe(gulp.dest('./css');
 
 // will write the source maps inline in the compiled CSS files
 ```
@@ -71,7 +71,7 @@ gulp.src('./scss/*.scss')
   .pipe(sourcemaps.init())
     .pipe(sass())
   .pipe(sourcemaps.write('./maps'))
-  .pipe('./css');
+  .pipe(gulp.dest('./css'));
 
 // will write the source maps to ./dest/css/maps
 ```


### PR DESCRIPTION
The example using sourcemaps in the README are missing `gulp.dest` in the pipe to output. This commit adds them.

The missing `gulp.dest` was causing an error:

```
TypeError: Object css/ has no method 'on'
    at Stream.pipe (stream.js:65:8)
    at Gulp.gulp.task.gulp.src.read (/app/gulpfile.js:114:10)
    at module.exports (/app/node_modules/gulp/node_modules/orchestrator/lib/runTask.js:34:7)
    at Gulp.Orchestrator._runTask (/app/node_modules/gulp/node_modules/orchestrator/index.js:273:3)
    at Gulp.Orchestrator._runStep (/app/node_modules/gulp/node_modules/orchestrator/index.js:214:10)
    at Gulp.Orchestrator.start (/app/node_modules/gulp/node_modules/orchestrator/index.js:134:8)
    at /usr/local/lib/node_modules/gulp/bin/gulp.js:129:20
    at process._tickCallback (node.js:419:13)
    at Function.Module.runMain (module.js:499:11)
    at startup (node.js:119:16)
```
