### PR TITLE
Fix sourceComments override with sourcemaps enabled (#153)

### DIFF
--- a/index.js
+++ b/index.js
@@ -22,11 +22,10 @@ module.exports = function (options) {
     }
 
     if (file.sourceMap) {
-      opts.sourceComments = 'map';
       opts.sourceMap = file.path;
     }
 
-    if (opts.sourceComments === 'map' || opts.sourceComments === 'normal') {
+    if (file.sourceMap || opts.sourceComments === 'map' || opts.sourceComments === 'normal') {
       opts.sourceMap = opts.sourceMap || '';
       opts.file = file.path;
     } else {


### PR DESCRIPTION
It is currently impossible to use source maps without also adding line number comments to the source, since gulp-sass overrides the `sourceComments` option when source maps are in use.

This seems not to be necessary; source maps work fine regardless of the value of sourceComments.

This patch removes the sourceComments override.

Fixes #153 (and #148 ?).