### PR TITLE
Gracefully handle invalid sourcemaps returned from node-sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,13 +47,15 @@ module.exports = function (options) {
         // gulp-sourcemaps needs sources' paths relative to file.base;
         // so alter the sources' paths to please gulp-sourcemaps.
         obj.map = obj.map.version ? obj.map : JSON.parse(obj.map);
-        obj.map.sources = obj.map.sources.map(function(source) {
-          var abs = path.resolve(path.dirname(file.path), source);
-          return path.relative(file.base, abs);
-        });
-        obj.map = JSON.stringify(obj.map);
+        if (obj.map && obj.map.length) {
+          obj.map.sources = obj.map.sources.map(function(source) {
+            var abs = path.resolve(path.dirname(file.path), source);
+            return path.relative(file.base, abs);
+          });
+          obj.map = JSON.stringify(obj.map);
 
-        applySourceMap(file, obj.map);
+          applySourceMap(file, obj.map);
+        }
       }
 
       handleOutput(obj, file, cb);


### PR DESCRIPTION
Let me prefix this with saying I know my use-case is unique, but I think this defensive check is still good.

This PR gracefully handles the case where `JSON.parse` fails to return an object because Libsass/node-sass has generated invalid data.

I'm on the Libsass team, and we work with the node-sass team to beta test upcoming releases. I'm currently beta testing Libsass 3.2.0 (yay!). Due to a recent refactor in our sourcemaps implementation the `obj.map` currently returns `'{}'` (string) for an empty sourcemap. This causes `JSON.parse` to return a non-object which causes cascading failures in gulp-sass.

There are however a decent amount of cases where `JSON.parse` [will not return an object](https://developer.mozilla.org/en/docs/Web/JavaScript/Reference/Global_Objects/JSON/parse#Examples) which this guard will protect against.

If nothing else this patch will greatly help the Libsass team get releases out faster! :innocent: :heart: 