### PR TITLE
Move node-sass from dependencies to peerDependencies.

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,12 +24,14 @@
     "clone": "~0.1.18",
     "gulp-util": "^3.0",
     "map-stream": "~0.1",
-    "node-sass": "2.0.0-beta",
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {
     "tape": "~2.3",
     "concat-stream": "~1.4"
+  },
+  "peerDependencies": {
+    "node-sass": "*"
   },
   "jshintConfig": {
     "laxcomma": true


### PR DESCRIPTION
If you change the location of `node-sass` in `package.json` from `dependencies` to `peerDependencies` then you can let the end user choose which version to install, but still require them to install something or it will fail.

When new version of `node-sass` are released, this will prevent you from having to update your dependencies in package.json to give users access to the newest versions.

http://blog.nodejs.org/2013/02/07/peer-dependencies/