### PR TITLE
Add lineNumber & fileName to emitted error

### DIFF
--- a/index.js
+++ b/index.js
@@ -69,6 +69,9 @@ module.exports = function (options) {
         opts.onError(err);
         return cb();
       }
+      
+      err.lineNumber = err.line;
+      err.fileName = err.file;
 
       return cb(new gutil.PluginError('gulp-sass', err));
     };


### PR DESCRIPTION
This PR improves the emitted error by (re)adding useful properties.

In `gulp-sass@1.3.2` / `node-sass@2.0.0-beta` the error message format has changed; instead of including the line number & file as part of the `err.message` string, an object is returned.

I see that the `errLogToConsole` method has been updated (https://github.com/dlmanning/gulp-sass/commit/55601e217b5bb579c825ad4089c19767e84c046e) to re-add the line & file properties but the errors emitted into the stream with `return cb(new gutil.PluginError('gulp-sass', err))` ([index.js#L73](https://github.com/dlmanning/gulp-sass/blob/master/index.js#L73)) are missing the line number & file name as the only properties `gutil.PluginError` preserves are `'name', 'message', 'fileName', 'lineNumber', 'stack', 'showStack', 'showProperties', 'plugin'` ([PluginError.js#L49](https://github.com/gulpjs/gulp-util/blob/master/lib/PluginError.js#L49)) whereas the property names returned by `libsass` are `err.file` & `err.line`.