### PR TITLE
Added test case for #187

### DIFF
--- a/test/ref/bug-187.css
+++ b/test/ref/bug-187.css
@@ -1,0 +1,2 @@
+body .div {
+  color: blue; }

--- a/test/scss/bug-187.sass
+++ b/test/scss/bug-187.sass
@@ -1,0 +1,4 @@
+$color: blue
+
+body .div
+  color: $color

--- a/test/test.js
+++ b/test/test.js
@@ -198,3 +198,25 @@ test('sourcemaps', function (t) {
   });
   stream.write(sassFile);
 });
+
+// These are files that had specific gulp-sass bugs
+test('former bugs', function (t) {
+  var sassFile = createVinyl('bug-187.sass');
+
+  var stream = gsass();
+  stream.on('data', function (cssFile) {
+    t.ok(cssFile, 'cssFile should exist');
+    t.ok(cssFile.path, 'cssFile.path should exist');
+    t.ok(cssFile.relative, 'cssFile.relative should exist');
+    t.ok(cssFile.contents, 'cssFile.contents should exist');
+    t.equal(cssFile.path, path.join(__dirname, 'scss', 'bug-187.css'));
+    t.equal(
+      fs.readFileSync(path.join(__dirname, 'ref/bug-187.css'), 'utf8'),
+      cssFile.contents.toString(),
+      'file compiles correctly to css'
+    );
+    t.end();
+  });
+  stream.write(sassFile);
+});
+


### PR DESCRIPTION
Current output:

```
❯ npm test | faucet
✓ pass file when isNull()
✓ compile a single sass file
✓ compile a single sass file synchronously
✓ compile multiple sass files
✓ compile multiple sass files with includePaths
✓ emit error on sass errors
✓ emit error on sass errors when using sync true
✓ call custom error callback when opts.onError is given
✓ sourcemaps
# former bugs

/Users/callumacrae/Sites/gulp-sass/node_modules/tape/index.js:65
        throw err
              ^
Error: error reading values after body
npm ERR! Test failed.  See above for more details.
✓ former bugsok code 0
not ok 42 no plan found
⨯ fail  1
```