### PR TITLE
Update node-sass to 3.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "~0.1.18",
     "gulp-util": "^3.0",
     "map-stream": "~0.1",
-    "node-sass": "^2.0.1",
+    "node-sass": "^3.0.0-pre",
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {

--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "~0.1.18",
     "gulp-util": "^3.0",
     "map-stream": "~0.1",
-    "node-sass": "^3.0.0-pre",
+    "node-sass": "^3.0.0-alpha.0",
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
node-sass removed success/error callback
https://github.com/sass/node-sass/pull/726
Switched them to a single callback function

It also now returns buffer instead of string.

See https://github.com/sass/node-sass/releases for list of changes

Note: there is a hack for the obj.css with sourcemap, not
sure what to do there