### PR TITLE
Format `errLogToConsole` message with red color

### DIFF
--- a/index.js
+++ b/index.js
@@ -65,7 +65,7 @@ module.exports = function (options) {
 
     opts.error = function (err) {
       if (opts.errLogToConsole) {
-        gutil.log('[gulp-sass] ' + err.message + ' on line ' + err.line + ' in ' + err.file);
+        gutil.log(gutil.colors.red('[gulp-sass]', err.message, 'on line', err.line + 'in', err.file));
         return cb();
       }
 


### PR DESCRIPTION
Makes it more obvious that an error has occurred, similar to how Ruby Sass handles errors during compilation.

Also removed the `+`'s, cleaner with separate arguments, `gutil.log()` will format it correctly.