### PR TITLE
Added preservation of options.data.

### DIFF
--- a/index.js
+++ b/index.js
@@ -25,7 +25,8 @@ module.exports = function (options) {
       opts.sourceMap = file.path;
     }
 
-    opts.data = file.contents.toString();
+	opts.data = opts.data || '';
+    opts.data += file.contents.toString();
     opts.file = file.path;
 
     if (opts.includePaths && Array.isArray(opts.includePaths)) {


### PR DESCRIPTION
According to Gulp-Sass: "Options passed as a hash into sass() will be passed along to node-sass." Except this is not true for `options.data` which is a useful option for overriding settings, etc. This PR adds preservation of any existing `data` option.