### PR TITLE
Sourcemap paths seem to be relative now?

### DIFF
--- a/index.js
+++ b/index.js
@@ -40,23 +40,9 @@ module.exports = function(options) {
         ));
       }
 
-      // Build Source Maps!
       if (obj.map) {
-        // libsass gives us sources' paths relative to file;
-        // gulp-sourcemaps needs sources' paths relative to file.base;
-        // so alter the sources' paths to please gulp-sourcemaps.
-        obj.map = JSON.parse(obj.map.toString());
-
-        if (obj.map.sources) {
-          obj.map.sources = obj.map.sources.map(function(source) {
-            var abs = path.resolve(path.dirname(file.path), source);
-            return path.relative(file.base, abs);
-          });
-
-          obj.map = JSON.stringify(obj.map);
-          applySourceMap(file, obj.map);
+          applySourceMap(file, JSON.parse(obj.map.toString()));
         }
-      }
 
       file.contents = obj.css;
       file.path = gutil.replaceExtension(file.path, '.css');

--- a/package.json
+++ b/package.json
@@ -4,7 +4,7 @@
   "description": "Gulp plugin for sass",
   "main": "index.js",
   "scripts": {
-    "test": "./node_modules/.bin/jshint index.js && ./node_modules/.bin/mocha test"
+    "test": "./node_modules/.bin/mocha test"
   },
   "repository": {
     "type": "git",
@@ -29,7 +29,6 @@
   },
   "devDependencies": {
     "eslint": "^0.17.1",
-    "jshint": "^2.6.3",
     "mocha": "^2.2.1",
     "should": "^5.2.0"
   }


### PR DESCRIPTION
At least the test still pass and paths looks the same with and without the relative fudge.
Sourcemaps are completely wonky though and do not point at the right thing

Also removes jshint since it's using eslint now