### PR TITLE
2.x filedata

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ var gulpSass = function gulpSass(options, sync) {
     var opts,
         ip,
         filePush,
+        sassMap,
+        sassMapFile,
+        sassFileSrc,
         errorM,
         callback,
         result;
@@ -59,7 +62,18 @@ var gulpSass = function gulpSass(options, sync) {
     filePush = function filePush(sassObj) {
       // Build Source Maps!
       if (sassObj.map) {
-        applySourceMap(file, JSON.parse(sassObj.map.toString()));
+        // Transform map into JSON
+        sassMap = JSON.parse(sassObj.map.toString());
+        // Grab the stdout and transform it into stdin
+        sassMapFile = sassMap.file.replace('stdout', 'stdin');
+        // Grab the base file name that's being worked on
+        sassFileSrc = file.path.split('/').pop();
+        // Replace the stdin with the original file name
+        sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
+        // Replace the map file with the original file name
+        sassMap.file = sassFileSrc;
+        // Apply the map
+        applySourceMap(file, sassMap);
       }
 
       file.contents = sassObj.css;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ var gulpSass = function gulpSass(options, sync) {
     opts = assign({}, options);
     opts.data = file.contents.toString();
 
+    // If we have a .sass file, make sure indentedSyntax is passed
+    if (path.extname(file.path) === '.sass') {
+      opts.indentedSyntax = true;
+    }
+
+    // Make sure file's directory is in include path
     if (opts.includePaths) {
       if (typeof opts.includePaths === 'string') {
         opts.includePaths = [opts.includePaths];

--- a/index.js
+++ b/index.js
@@ -15,11 +15,7 @@ var PLUGIN_NAME = 'gulp-sass';
 var gulpSass = function gulpSass(options, sync) {
   return through.obj(function(file, enc, cb) {
     var opts,
-        ip,
         filePush,
-        sassMap,
-        sassMapFile,
-        sassFileSrc,
         errorM,
         callback,
         result;
@@ -39,9 +35,7 @@ var gulpSass = function gulpSass(options, sync) {
 
     if (opts.includePaths) {
       if (typeof opts.includePaths === 'string') {
-        ip = opts.includePaths;
-        opts.includePaths = [];
-        opts.includePaths.push(ip);
+        opts.includePaths = [opts.includePaths];
       }
     }
     else {
@@ -60,6 +54,10 @@ var gulpSass = function gulpSass(options, sync) {
     // Handles returning the file to the stream
     //////////////////////////////
     filePush = function filePush(sassObj) {
+      var sassMap,
+          sassMapFile,
+          sassFileSrc;
+
       // Build Source Maps!
       if (sassObj.map) {
         // Transform map into JSON

--- a/test/expected/indent.css
+++ b/test/expected/indent.css
@@ -1,0 +1,3 @@
+#main {
+  color: blue;
+  font-size: 0.3em; }

--- a/test/expected/indent.css
+++ b/test/expected/indent.css
@@ -1,3 +1,2 @@
-#main {
-  color: blue;
-  font-size: 0.3em; }
+body .div {
+  color: blue; }

--- a/test/expected/inheritance.css
+++ b/test/expected/inheritance.css
@@ -1,6 +1,9 @@
 body {
   background: pink; }
 
+footer {
+  background: red; }
+
 .error, .badError {
   border: #f00;
   background: #fdd; }

--- a/test/main.js
+++ b/test/main.js
@@ -196,6 +196,53 @@ describe('gulp-sass -- async compile', function() {
     });
     stream.write(sassFile);
   });
+
+  it('should compile a single indented sass file', function(done) {
+    var sassFile = createVinyl('indent.sass');
+    var stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal(
+	fs.readFileSync(path.join(__dirname, 'expected/indent.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
+  it('should parse files in sass and scss', function(done) {
+    var files = [
+      createVinyl('mixins.scss'),
+      createVinyl('indent.sass')
+    ];
+    var stream = sass();
+    var mustSee = files.length;
+    var expectedPath = 'expected/mixins.css';
+
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      if (cssFile.path.indexOf('indent') !== -1) {
+	expectedPath = 'expected/indent.css';
+      }
+      String(cssFile.contents).should.equal(
+	fs.readFileSync(path.join(__dirname, expectedPath), 'utf8')
+      );
+      mustSee--;
+      if (mustSee <= 0) {
+	done();
+      }
+    });
+
+    files.forEach(function (file) {
+      stream.write(file);
+    });
+  });
 });
 
 describe('gulp-sass -- sync compile', function() {

--- a/test/main.js
+++ b/test/main.js
@@ -131,7 +131,7 @@ describe('gulp-sass -- async compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
-      '../../stdin'
+      'inheritance.scss'
     ];
 
     var stream;

--- a/test/main.js
+++ b/test/main.js
@@ -357,6 +357,7 @@ describe('gulp-sass -- sync compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
+      'includes/_dogs.sass',
       'inheritance.scss'
     ];
 
@@ -374,7 +375,7 @@ describe('gulp-sass -- sync compile', function() {
     stream = sass.sync();
     stream.on('data', function(cssFile) {
       should.exist(cssFile.sourceMap);
-      assert.deepEqual(cssFile.sourceMap.sources, expectedSources);
+      cssFile.sourceMap.sources.should.eql(expectedSources);
       done();
     });
     stream.write(sassFile);

--- a/test/main.js
+++ b/test/main.js
@@ -5,7 +5,6 @@ var gutil = require('gulp-util');
 var path = require('path');
 var fs = require('fs');
 var sass = require('../index');
-var assert = require('assert');
 
 var createVinyl = function createVinyl(filename, contents) {
   var base = path.join(__dirname, 'scss');
@@ -174,6 +173,7 @@ describe('gulp-sass -- async compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
+      'includes/_dogs.sass',
       'inheritance.scss'
     ];
 
@@ -191,7 +191,7 @@ describe('gulp-sass -- async compile', function() {
     stream = sass();
     stream.on('data', function(cssFile) {
       should.exist(cssFile.sourceMap);
-      assert.deepEqual(cssFile.sourceMap.sources, expectedSources);
+      cssFile.sourceMap.sources.should.eql(expectedSources);
       done();
     });
     stream.write(sassFile);

--- a/test/main.js
+++ b/test/main.js
@@ -125,6 +125,49 @@ describe('gulp-sass -- async compile', function() {
     stream.write(errorFile);
   });
 
+   it('should compile a single sass file if the file name has been changed in the stream', function(done) {
+    var sassFile = createVinyl('mixins.scss');
+    var stream;
+
+    // Transform file name
+    sassFile.path = path.join(path.join(__dirname, 'scss'), 'mixin--changed.scss');
+
+    stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      cssFile.path.split('/').pop().should.equal('mixin--changed.css');
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal(
+        fs.readFileSync(path.join(__dirname, 'expected/mixins.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
+  it('should preserve changes made in-stream to a Sass file', function(done) {
+    var sassFile = createVinyl('mixins.scss');
+    var stream;
+
+    // Transform file name
+    sassFile.contents = new Buffer('/* Added Dynamically */' + sassFile.contents.toString());
+
+    stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal('/* Added Dynamically */\n' +
+        fs.readFileSync(path.join(__dirname, 'expected/mixins.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
   it('should work with gulp-sourcemaps', function(done) {
     var sassFile = createVinyl('inheritance.scss');
 

--- a/test/main.js
+++ b/test/main.js
@@ -131,7 +131,7 @@ describe('gulp-sass -- async compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
-      'inheritance.scss'
+      '../../stdin'
     ];
 
     var stream;

--- a/test/scss/includes/_dogs.sass
+++ b/test/scss/includes/_dogs.sass
@@ -1,0 +1,5 @@
+$blue: #3bbfce;
+$margin: 16px;
+
+footer
+  background: red;

--- a/test/scss/indent.sass
+++ b/test/scss/indent.sass
@@ -1,0 +1,3 @@
+#main
+  color: blue
+  font-size: 0.3em

--- a/test/scss/indent.sass
+++ b/test/scss/indent.sass
@@ -1,3 +1,4 @@
-#main
-  color: blue
-  font-size: 0.3em
+$color: blue
+
+body .div
+  color: $color

--- a/test/scss/inheritance.scss
+++ b/test/scss/inheritance.scss
@@ -1,4 +1,5 @@
 @import "includes/cats";
+@import "includes/dogs";
 
 .error {
   border: #f00;


### PR DESCRIPTION
* Passes file as data instead of passing file name
* Updates error message handling to show real file name instead of `stdin`
* Reimplements `includePaths` handling so we can pass file data directly
* Massages source maps to replace `stdin` and `stdout` with the right file names
* Resolves #158

Do we think we should have tests specifically for the issues going on in there? I've done some basic tests to determine if it works, but nothing more in-depth.