### PR TITLE
2.x datastream

### DIFF
--- a/index.js
+++ b/index.js
@@ -17,6 +17,9 @@ var gulpSass = function gulpSass(options, sync) {
     var opts,
         ip,
         filePush,
+        sassMap,
+        sassMapFile,
+        sassFileSrc,
         errorM,
         callback,
         result;
@@ -59,7 +62,18 @@ var gulpSass = function gulpSass(options, sync) {
     filePush = function filePush(sassObj) {
       // Build Source Maps!
       if (sassObj.map) {
-        applySourceMap(file, JSON.parse(sassObj.map.toString()));
+        // Transform map into JSON
+        sassMap = JSON.parse(sassObj.map.toString());
+        // Grab the stdout and transform it into stdin
+        sassMapFile = sassMap.file.replace('stdout', 'stdin');
+        // Grab the base file name that's being worked on
+        sassFileSrc = file.path.split('/').pop();
+        // Replace the stdin with the original file name
+        sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
+        // Replace the map file with the original file name
+        sassMap.file = sassFileSrc;
+        // Apply the map
+        applySourceMap(file, sassMap);
       }
 
       file.contents = sassObj.css;

--- a/index.js
+++ b/index.js
@@ -33,6 +33,12 @@ var gulpSass = function gulpSass(options, sync) {
     opts = assign({}, options);
     opts.data = file.contents.toString();
 
+    // Ensure `indentedSyntax` is true if a `.sass` file
+    if (path.extname(file.path) === '.sass') {
+      opts.indentedSyntax = true;
+    }
+
+    // Ensure file's parent directory in the include path
     if (opts.includePaths) {
       if (typeof opts.includePaths === 'string') {
         opts.includePaths = [opts.includePaths];

--- a/index.js
+++ b/index.js
@@ -15,11 +15,7 @@ var PLUGIN_NAME = 'gulp-sass';
 var gulpSass = function gulpSass(options, sync) {
   return through.obj(function(file, enc, cb) {
     var opts,
-        ip,
         filePush,
-        sassMap,
-        sassMapFile,
-        sassFileSrc,
         errorM,
         callback,
         result;
@@ -39,9 +35,7 @@ var gulpSass = function gulpSass(options, sync) {
 
     if (opts.includePaths) {
       if (typeof opts.includePaths === 'string') {
-        ip = opts.includePaths;
-        opts.includePaths = [];
-        opts.includePaths.push(ip);
+        opts.includePaths = [opts.includePaths];
       }
     }
     else {
@@ -60,6 +54,10 @@ var gulpSass = function gulpSass(options, sync) {
     // Handles returning the file to the stream
     //////////////////////////////
     filePush = function filePush(sassObj) {
+      var sassMap,
+          sassMapFile,
+          sassFileSrc;
+
       // Build Source Maps!
       if (sassObj.map) {
         // Transform map into JSON

--- a/test/main.js
+++ b/test/main.js
@@ -131,7 +131,7 @@ describe('gulp-sass -- async compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
-      '../../stdin'
+      'inheritance.scss'
     ];
 
     var stream;

--- a/test/main.js
+++ b/test/main.js
@@ -125,6 +125,49 @@ describe('gulp-sass -- async compile', function() {
     stream.write(errorFile);
   });
 
+   it('should compile a single sass file if the file name has been changed in the stream', function(done) {
+    var sassFile = createVinyl('mixins.scss');
+    var stream;
+
+    // Transform file name
+    sassFile.path = path.join(path.join(__dirname, 'scss'), 'mixin--changed.scss');
+
+    stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      cssFile.path.split('/').pop().should.equal('mixin--changed.css');
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal(
+        fs.readFileSync(path.join(__dirname, 'expected/mixins.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
+  it('should preserve changes made in-stream to a Sass file', function(done) {
+    var sassFile = createVinyl('mixins.scss');
+    var stream;
+
+    // Transform file name
+    sassFile.contents = new Buffer('/* Added Dynamically */' + sassFile.contents.toString());
+
+    stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal('/* Added Dynamically */\n' +
+        fs.readFileSync(path.join(__dirname, 'expected/mixins.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
   it('should work with gulp-sourcemaps', function(done) {
     var sassFile = createVinyl('inheritance.scss');
 

--- a/test/main.js
+++ b/test/main.js
@@ -131,7 +131,7 @@ describe('gulp-sass -- async compile', function() {
     // Expected sources are relative to file.base
     var expectedSources = [
       'includes/_cats.scss',
-      'inheritance.scss'
+      '../../stdin'
     ];
 
     var stream;


### PR DESCRIPTION
Reroll of #225

* Passes file as data instead of passing file name
* Updates error message handling to show real file name instead of `stdin`
* Reimplements `includePaths` handling so we can pass file data directly
* Massages source maps to replace `stdin` and `stdout` with the right file names
* Resolves #158, #202

Do we think we should have tests specifically for the issues going on in there? I've done some basic tests to determine if it works, but nothing more in-depth.