### PR TITLE
Allow you to change the compiler and expose it

### DIFF
--- a/index.js
+++ b/index.js
@@ -4,7 +4,6 @@ var gutil = require('gulp-util');
 var through = require('through2');
 var assign = require('object-assign');
 var path = require('path');
-var sass = require('node-sass');
 var applySourceMap = require('vinyl-sourcemaps-apply');
 
 var PLUGIN_NAME = 'gulp-sass';
@@ -117,14 +116,14 @@ var gulpSass = function gulpSass(options, sync) {
         filePush(obj);
       };
 
-      sass.render(opts, callback);
+      gulpSass.compiler.render(opts, callback);
     }
     else {
       //////////////////////////////
       // Sync Sass render
       //////////////////////////////
       try {
-        result = sass.renderSync(opts);
+        result = gulpSass.compiler.renderSync(opts);
 
         filePush(result);
       }
@@ -148,5 +147,10 @@ gulpSass.sync = function sync(options) {
 gulpSass.logError = function logError(error) {
   gutil.log(gutil.colors.red('[' + PLUGIN_NAME + '] ') + error.message);
 };
+
+//////////////////////////////
+// Store compiler in a prop
+//////////////////////////////
+gulpSass.compiler = require('node-sass');
 
 module.exports = gulpSass;


### PR DESCRIPTION
This will let you write `require('gulp-sass').compiler.types`, for example, and access
the new `node-sass` [types](https://github.com/sass/node-sass#typesnumbervalue--unit--) without having to `require('node-sass')` in your own code.

Additionally, this lets you use a forked compiler, or a different branch
of the same compiler, by overriding `require('gulp-sass').compiler`.

What do you think?