### PR TITLE
Add support for node-sass >= 3.0.0-beta.7

### DIFF
--- a/package.json
+++ b/package.json
@@ -24,7 +24,7 @@
     "clone": "~0.1.18",
     "gulp-util": "^3.0",
     "map-stream": "~0.1",
-    "node-sass": "^2.0.1",
+    "node-sass": "^3.0.0-beta.7",
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {


### PR DESCRIPTION
This PR adds support for node-sass >= 3.0.0-beta.7.

I admit to not being familiar with gulp plugins, so this may need some review.
All the tests pass.

Fixes https://github.com/dlmanning/gulp-sass/issues/210.