### PR TITLE
Fix issue with sourcemaps when using gulp-sourcemaps and autoprefixer

### DIFF
--- a/index.js
+++ b/index.js
@@ -73,8 +73,8 @@ var gulpSass = function gulpSass(options, sync) {
         sassFileSrc = file.path.split('/').pop();
         // Replace the stdin with the original file name
         sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
-        // Replace the map file with the original file name
-        sassMap.file = sassFileSrc;
+        // Replace the map file with the original file name (but new extension)
+        sassMap.file = gutil.replaceExtension(sassFileSrc, '.css');
         // Apply the map
         applySourceMap(file, sassMap);
       }

--- a/package.json
+++ b/package.json
@@ -28,7 +28,12 @@
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {
+    "autoprefixer-core": "^5.1.11",
     "eslint": "^0.17.1",
+    "gulp": "^3.8.11",
+    "gulp-postcss": "^5.1.6",
+    "gulp-sourcemaps": "^1.5.2",
+    "gulp-tap": "^0.1.3",
     "mocha": "^2.2.1",
     "should": "^5.2.0"
   }

--- a/test/main.js
+++ b/test/main.js
@@ -5,6 +5,11 @@ var gutil = require('gulp-util');
 var path = require('path');
 var fs = require('fs');
 var sass = require('../index');
+var gulp = require('gulp');
+var sourcemaps = require('gulp-sourcemaps');
+var postcss = require('gulp-postcss');
+var autoprefixer = require('autoprefixer-core');
+var tap = require('gulp-tap');
 
 var createVinyl = function createVinyl(filename, contents) {
   var base = path.join(__dirname, 'scss');
@@ -379,5 +384,29 @@ describe('gulp-sass -- sync compile', function() {
       done();
     });
     stream.write(sassFile);
+  });
+
+  it('should work with gulp-sourcemaps and autoprefixer', function(done) {
+    var expectedSources = [
+      'includes/_cats.scss',
+      'includes/_dogs.sass',
+      'inheritance.scss'
+    ];
+
+    gulp.src(path.join(__dirname, '/scss/inheritance.scss'))
+      .pipe(sourcemaps.init())
+      .pipe(sass.sync())
+      .pipe(tap(function(file) {
+        should.exist(file.sourceMap);
+        file.sourceMap.sources.should.eql(expectedSources);
+      }))
+      .pipe(postcss([autoprefixer()]))
+      .pipe(sourcemaps.write())
+      .pipe(gulp.dest(path.join(__dirname, '/results/')))
+      .pipe(tap(function(file) {
+        should.exist(file.sourceMap);
+        file.sourceMap.sources.should.eql(expectedSources);
+      }))
+      .on('end', done);
   });
 });


### PR DESCRIPTION
As described in [the comments of issue 106](https://github.com/dlmanning/gulp-sass/issues/106#issuecomment-100314779), I'm receiving an incomplete `sources` property when feeding the results from `gulp-sass` into `autoprefixer` (using `gulp-postcss` or `gulp-autoprefixer`). This was not the case in earlier versions of this plugin. As [suggested](https://github.com/dlmanning/gulp-sass/issues/106#issuecomment-100391439) by @w0rm, changing the file extension of the map's `file` property fixes the issue and the existing tests still succeed.