### PR TITLE
Unshift instead of push current file's path onto includePaths.

### DIFF
--- a/index.js
+++ b/index.js
@@ -47,7 +47,7 @@ var gulpSass = function gulpSass(options, sync) {
       opts.includePaths = [];
     }
 
-    opts.includePaths.push(path.dirname(file.path));
+    opts.includePaths.unshift(path.dirname(file.path));
 
     // Generate Source Maps if plugin source-map present
     if (file.sourceMap) {


### PR DESCRIPTION
If the current file's path is placed at the end, it will be the last folder to check for imports. Which I feel is incorrect.