### PR TITLE
Fix gulp watch stopping on error.

### DIFF
--- a/index.js
+++ b/index.js
@@ -148,7 +148,8 @@ gulpSass.sync = function sync(options) {
 // Log errors nicely
 //////////////////////////////
 gulpSass.logError = function logError(error) {
-  gutil.log(gutil.colors.red('[' + PLUGIN_NAME + '] ') + error.messageFormatted);
+  var message = new gutil.PluginError('sass', error.messageFormatted).toString();
+  process.stderr.write(message + '\n');
   this.emit('end');
 };
 

--- a/index.js
+++ b/index.js
@@ -149,6 +149,7 @@ gulpSass.sync = function sync(options) {
 //////////////////////////////
 gulpSass.logError = function logError(error) {
   gutil.log(gutil.colors.red('[' + PLUGIN_NAME + '] ') + error.messageFormatted);
+  this.emit('end');
 };
 
 //////////////////////////////


### PR DESCRIPTION
Fixes #90. Related to: https://github.com/gulpjs/gulp/issues/259

I think recommending people to not `return` the gulp stream is not a good idea, because gulp will not know when the task is complete, therefore any tasks that depend on sass being done will not be guaranteed that (think race conditions).