### PR TITLE
Fix: gulp-sass stops watching after error occures

### DIFF
--- a/index.js
+++ b/index.js
@@ -152,6 +152,7 @@ gulpSass.sync = function sync(options) {
 //////////////////////////////
 gulpSass.logError = function logError(error) {
   gutil.log(gutil.colors.red('[' + PLUGIN_NAME + '] ') + error.messageFormatted);
+  this.emit('end');
 };
 
 //////////////////////////////


### PR DESCRIPTION
Gulp-sass builtin error reporting, needs to emit 'end' on error as it discussed in google/web-starter-kit#708.