### PR TITLE
Modify sourcemap paths of imported files

### DIFF
--- a/index.js
+++ b/index.js
@@ -57,6 +57,7 @@ var gulpSass = function gulpSass(options, sync) {
     if (file.sourceMap) {
       opts.sourceMap = file.path;
       opts.omitSourceMapUrl = true;
+      opts.sourceMapContents = true;
     }
 
     //////////////////////////////
@@ -65,7 +66,9 @@ var gulpSass = function gulpSass(options, sync) {
     filePush = function filePush(sassObj) {
       var sassMap,
           sassMapFile,
-          sassFileSrc;
+          sassFileSrc,
+          sassFileSrcPath,
+          sourceFileIndex;
 
       // Build Source Maps!
       if (sassObj.map) {
@@ -75,6 +78,16 @@ var gulpSass = function gulpSass(options, sync) {
         sassMapFile = sassMap.file.replace('stdout', 'stdin');
         // Grab the base file name that's being worked on
         sassFileSrc = file.relative;
+        // Grab the path portion of the file that's being worked on
+        sassFileSrcPath = sassFileSrc.substring(0, sassFileSrc.lastIndexOf('/'));
+        if (sassFileSrcPath) {
+          //Prepend the path to all files in the sources array except the file that's being worked on
+          for (sourceFileIndex = 0; sourceFileIndex < sassMap.sources.length; sourceFileIndex++) {
+            if (sourceFileIndex !== sassMap.sources.indexOf(sassMapFile)) {
+              sassMap.sources[sourceFileIndex] = sassFileSrcPath + '/' + sassMap.sources[sourceFileIndex];
+            }
+          }
+        }
         // Replace the stdin with the original file name
         sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
         // Replace the map file with the original file name (but new extension)

--- a/index.js
+++ b/index.js
@@ -79,9 +79,7 @@ var gulpSass = function gulpSass(options, sync) {
         // Grab the base file name that's being worked on
         sassFileSrc = file.relative;
         // Grab the path portion of the file that's being worked on
-        sassFileSrcPath = sassFileSrc.split(path.sep);
-        sassFileSrcPath.pop();
-        sassFileSrcPath = sassFileSrcPath.join(path.sep);
+        sassFileSrcPath = path.dirname(sassFileSrc);
         if (sassFileSrcPath) {
           //Prepend the path to all files in the sources array except the file that's being worked on
           for (sourceFileIndex = 0; sourceFileIndex < sassMap.sources.length; sourceFileIndex++) {

--- a/index.js
+++ b/index.js
@@ -79,12 +79,14 @@ var gulpSass = function gulpSass(options, sync) {
         // Grab the base file name that's being worked on
         sassFileSrc = file.relative;
         // Grab the path portion of the file that's being worked on
-        sassFileSrcPath = sassFileSrc.substring(0, sassFileSrc.lastIndexOf('/'));
+        sassFileSrcPath = sassFileSrc.split(path.sep);
+        sassFileSrcPath.pop();
+        sassFileSrcPath = sassFileSrcPath.join(path.sep);
         if (sassFileSrcPath) {
           //Prepend the path to all files in the sources array except the file that's being worked on
           for (sourceFileIndex = 0; sourceFileIndex < sassMap.sources.length; sourceFileIndex++) {
             if (sourceFileIndex !== sassMap.sources.indexOf(sassMapFile)) {
-              sassMap.sources[sourceFileIndex] = sassFileSrcPath + '/' + sassMap.sources[sourceFileIndex];
+              sassMap.sources[sourceFileIndex] = path.join(sassFileSrcPath, sassMap.sources[sourceFileIndex]);
             }
           }
         }

--- a/test/main.js
+++ b/test/main.js
@@ -438,8 +438,8 @@ describe('gulp-sass -- sync compile', function() {
 
   it('should work with gulp-sourcemaps and autoprefixer with different file.base', function(done) {
     var expectedSources = [
-      'includes/_cats.scss',
-      'includes/_dogs.sass',
+      'scss/includes/_cats.scss',
+      'scss/includes/_dogs.sass',
       'scss/inheritance.scss'
     ];
 


### PR DESCRIPTION
Modify sourcemap paths of imported files relative to file.base instead of relative to file, if a different base is specified. Resolves #319 