### PR TITLE
Add option to compile underscored (partials) files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gulp Sass Changelog
 
+## v2.0.5
+**September 18, 2015**
+
+* **New** Added `compilePartials` option that can be used to process partials from `gulp.src()`. 
+
 ## v2.0.4
 **July 15, 2015**
 

--- a/README.md
+++ b/README.md
@@ -54,6 +54,14 @@ gulp.task('sass:watch', function () {
 
 Pass in options just like you would for [`node-sass`](https://github.com/sass/node-sass#options); they will be passed along just as if you were using `node-sass`.
 
+There is only one additional option to process underscored files:
+```js
+ gulp.task('sass', function () {
+ gulp.src('./sass/**/*.scss')
+   .pipe(sass({compilePartials: true}))
+   .pipe(gulp.dest('./css'));
+```
+
 For example:
 ```js
  gulp.task('sass', function () {

--- a/index.js
+++ b/index.js
@@ -25,9 +25,6 @@ var gulpSass = function gulpSass(options, sync) {
     if (file.isStream()) {
       return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
     }
-    if (path.basename(file.path).indexOf('_') === 0) {
-      return cb();
-    }
     if (!file.contents.length) {
       return cb(null, file);
     }
@@ -35,6 +32,10 @@ var gulpSass = function gulpSass(options, sync) {
 
     opts = assign({}, options);
     opts.data = file.contents.toString();
+
+    if ((path.basename(file.path).indexOf('_') === 0) && (!opts.processUnderscored)) {
+      return cb();
+    }
 
     // Ensure `indentedSyntax` is true if a `.sass` file
     if (path.extname(file.path) === '.sass') {

--- a/index.js
+++ b/index.js
@@ -33,7 +33,7 @@ var gulpSass = function gulpSass(options, sync) {
     opts = assign({}, options);
     opts.data = file.contents.toString();
 
-    if ((path.basename(file.path).indexOf('_') === 0) && (!opts.processUnderscored)) {
+    if ((path.basename(file.path).indexOf('_') === 0) && (opts.compilePartials !== true)) {
       return cb();
     }
 

--- a/test/expected/_partial.css
+++ b/test/expected/_partial.css
@@ -1,0 +1,2 @@
+body {
+  background: red; }

--- a/test/main.js
+++ b/test/main.js
@@ -72,6 +72,22 @@ describe('gulp-sass -- async compile', function() {
     stream.write(sassFile);
   });
 
+  it('should compile partial sass file with option', function(done) {
+    var sassFile = createVinyl('_partial.scss');
+    var stream = sass({ 'compilePartials': true });
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal(
+        fs.readFileSync(path.join(__dirname, 'expected/_partial.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
   it('should compile multiple sass files', function(done) {
     var files = [
       createVinyl('mixins.scss'),


### PR DESCRIPTION
Sometimes it's needed to compile this type of files, for example to create tests. And ``node-sass`` will process it if you specify it directly. So I found that it may be useful.

Related to #333 