### PR TITLE
Use node-sass@3.4.0-beta

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0",
-    "node-sass": "^3.0.0",
+    "node-sass": "^3.4.0-beta1",
     "object-assign": "^2.0.0",
     "through2": "^0.6.3",
     "vinyl-sourcemaps-apply": "~0.1.1"

--- a/test/main.js
+++ b/test/main.js
@@ -129,7 +129,7 @@ describe('gulp-sass -- async compile', function() {
       // Error must include file error occurs in
       err.message.indexOf('test/scss/error.scss').should.not.equal(-1);
       // Error must include line and column error occurs on
-      err.message.indexOf('2:7').should.not.equal(-1);
+      err.message.indexOf('2:3').should.not.equal(-1);
       done();
     });
     stream.write(errorFile);


### PR DESCRIPTION
We've started releasing the [LibSass 3.3.0 betas](https://github.com/sass/libsass/releases/tag/3.3.0-beta1). In order to truly beta test LibSass 3.3.0 we real users to have the option to use it. Unfortunately due to the nature of LibSass being a library, the majority of our users come from node-sass via Grunt/Gulp Sass.

Node sass has start releasing their [v3.4.0 betas](https://github.com/sass/node-sass/releases/tag/v3.4.0-beta1) which enables the new LibSass betas.

We'd like for gulp-sass to release a 2.1.0 beta with an updated `node-sass@^v3.4.0-beta1` dependency so gulp-sass users can opt into beta testing LibSass 3.3.0. Using this version string means users _should_ be opted into all Node Sass 3.4.0 betas. 

Once Node Sass 3.4.0 is stable, Gulp Sass 2.1.0 stable can be released with `node-sass@v3.4.0`.

```
LibSass 3.3.0-betaX --> Node Sass 3.4.0-betaX --> Gulp Sass 2.1.0-beta
```