### PR TITLE
add the .file property to options before handing off to node-sass

### DIFF
--- a/index.js
+++ b/index.js
@@ -36,6 +36,7 @@ var gulpSass = function gulpSass(options, sync) {
 
     opts = assign({}, options);
     opts.data = file.contents.toString();
+    opts.file = file.path;
 
     // Ensure `indentedSyntax` is true if a `.sass` file
     if (path.extname(file.path) === '.sass') {

--- a/index.js
+++ b/index.js
@@ -36,24 +36,14 @@ var gulpSass = function gulpSass(options, sync) {
 
     opts = assign({}, options);
     opts.data = file.contents.toString();
+
+    // we set the file path here so that libsass can correctly resolve import paths
     opts.file = file.path;
 
     // Ensure `indentedSyntax` is true if a `.sass` file
     if (path.extname(file.path) === '.sass') {
       opts.indentedSyntax = true;
     }
-
-    // Ensure file's parent directory in the include path
-    if (opts.includePaths) {
-      if (typeof opts.includePaths === 'string') {
-        opts.includePaths = [opts.includePaths];
-      }
-    }
-    else {
-      opts.includePaths = [];
-    }
-
-    opts.includePaths.unshift(path.dirname(file.path));
 
     // Generate Source Maps if plugin source-map present
     if (file.sourceMap) {


### PR DESCRIPTION
This sets the `file` property on the options object that gets passed along to node-sass.

This is important for using [`eyeglass`](https://github.com/sass-eyeglass/eyeglass) modules. `eyeglass` uses a custom importer and without knowing the file path origin, it isn't able to do it's job correctly.

Note that this doesn't really change how node-sass is going to render the file as `data` still takes precedence over `file`. This is just preserving the origin of the file.

Related issues:
https://github.com/sass-eyeglass/eyeglass/issues/64
https://github.com/sass-eyeglass/eyeglass/issues/42

Fixes #324

/cc @chriseppstein