### PR TITLE
An empty Sass file should produce an empty CSS file

### DIFF
--- a/index.js
+++ b/index.js
@@ -29,6 +29,7 @@ var gulpSass = function gulpSass(options, sync) {
       return cb();
     }
     if (!file.contents.length) {
+      file.path = gutil.replaceExtension(file.path, '.css');
       return cb(null, file);
     }
 

--- a/test/main.js
+++ b/test/main.js
@@ -56,6 +56,23 @@ describe('gulp-sass -- async compile', function() {
     stream.write(streamFile);
   });
 
+  it('should compile an empty sass file', function(done) {
+    var sassFile = createVinyl('empty.scss');
+    var stream = sass();
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      should.equal(path.basename(cssFile.path), 'empty.css');
+      String(cssFile.contents).should.equal(
+        fs.readFileSync(path.join(__dirname, 'expected/empty.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
+
   it('should compile a single sass file', function(done) {
     var sassFile = createVinyl('mixins.scss');
     var stream = sass();
@@ -462,6 +479,14 @@ describe('gulp-sass -- sync compile', function() {
     gulp.src(path.join(__dirname, '/scss/empty.scss'))
       .pipe(sass.sync())
       .pipe(gulp.dest(path.join(__dirname, '/results/')))
+      .pipe(tap(function() {
+        try {
+          fs.statSync(path.join(__dirname, '/results/empty.css'));
+        }
+        catch (e) {
+          should.fail(false, true, 'Empty file was produced');
+        }
+      }))
       .on('end', done);
   });
 });


### PR DESCRIPTION
Currently if the input file is blank we bail out early, returning
the input file object. This causes gulp to simply copy the input
Sass file. We instead need to rewrite the file extension to .css.
Fixes #352