### PR TITLE
Test runner should clean up after itself

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,6 +36,7 @@
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tap": "^0.1.3",
     "mocha": "^2.2.1",
+    "rimraf": "^2.4.3",
     "should": "^5.2.0"
   }
 }

--- a/test/main.js
+++ b/test/main.js
@@ -5,6 +5,7 @@ var gutil = require('gulp-util');
 var path = require('path');
 var fs = require('fs');
 var sass = require('../index');
+var rimraf = require('rimraf');
 var gulp = require('gulp');
 var sourcemaps = require('gulp-sourcemaps');
 var postcss = require('gulp-postcss');
@@ -257,6 +258,10 @@ describe('gulp-sass -- async compile', function() {
 });
 
 describe('gulp-sass -- sync compile', function() {
+  beforeEach(function(done) {
+    rimraf(path.join(__dirname, '/results/'), done);
+  });
+
   it('should pass file when it isNull()', function(done) {
     var stream = sass.sync();
     var emptyFile = {


### PR DESCRIPTION
We don't remove generated files between tests which results in
false positives when asserting if a file was created. This was
noticed when creating the test cases for #358