### PR TITLE
Update npm dependencies

### DIFF
--- a/.eslintrc
+++ b/.eslintrc
@@ -23,11 +23,10 @@ rules:
   # Disallow warning comments
   no-warning-comments:
     - 1
-    - terms
+    - terms:
         - todo
         - fixme
-      location
-        - anywhere
+      location: anywhere
 
   # Warns when variables are defined but never used
   no-unused-vars: 1
@@ -114,7 +113,6 @@ rules:
   space-after-keywords:
     - 2
     - always
-    - checkFunctionKeyword: true
 
   # Enforces quoted property names
   quote-props:
@@ -146,10 +144,17 @@ rules:
     - 2
     - single
 
-  # Enforces space inside of brackets (except property name)
-  space-in-brackets:
+  # Disallow or enforce spaces inside of curly braces in objects.
+  object-curly-spacing:
     - 2
     - always
-    - propertyName: false
-      singleValue: false
 
+  # Disallow or enforce spaces inside of brackets.
+  array-bracket-spacing:
+    - 2
+    - never
+
+  # Disallow or enforce spaces inside of computed properties.
+  computed-property-spacing:
+    - 2
+    - never

--- a/index.js
+++ b/index.js
@@ -147,7 +147,7 @@ var gulpSass = function gulpSass(options, sync) {
 
         filePush(result);
       }
-      catch(error) {
+      catch (error) {
         return errorM(error);
       }
     }

--- a/package.json
+++ b/package.json
@@ -28,15 +28,15 @@
     "vinyl-sourcemaps-apply": "~0.1.1"
   },
   "devDependencies": {
-    "autoprefixer-core": "^5.1.11",
-    "eslint": "^0.17.1",
+    "autoprefixer-core": "^5.0.0",
+    "eslint": "^1.6.0",
     "globule": "^0.2.0",
     "gulp": "^3.8.11",
-    "gulp-postcss": "^5.1.6",
+    "gulp-postcss": "^5.0.0",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tap": "^0.1.3",
     "mocha": "^2.2.1",
     "rimraf": "^2.4.3",
-    "should": "^5.2.0"
+    "should": "^7.1.0"
   }
 }

--- a/package.json
+++ b/package.json
@@ -23,9 +23,9 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "node-sass": "^3.4.0",
-    "object-assign": "^2.0.0",
-    "through2": "^0.6.3",
-    "vinyl-sourcemaps-apply": "~0.1.1"
+    "object-assign": "^4.0.1",
+    "through2": "^2.0.0",
+    "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
     "autoprefixer-core": "^5.0.0",


### PR DESCRIPTION
Some of our dependencies are at least a major version behind.

This require update required updating our `.eslintrc` config because
some of the rules we used have been removed.