### PR TITLE
Node Sass 3.4.0

### DIFF
--- a/index.js
+++ b/index.js
@@ -114,8 +114,7 @@ var gulpSass = function gulpSass(options, sync) {
       relativePath = path.relative(process.cwd(), filePath);
 
       message += gutil.colors.underline(relativePath) + '\n';
-      message += gutil.colors.gray('  ' + error.line + ':' + error.column) + '  ';
-      message += error.message;
+      message += error.formatted;
 
       error.messageFormatted = message;
       error.message = gutil.colors.stripColor(message);

--- a/package.json
+++ b/package.json
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0",
-    "node-sass": "^3.4.0-beta1",
+    "node-sass": "^3.4.0",
     "object-assign": "^2.0.0",
     "through2": "^0.6.3",
     "vinyl-sourcemaps-apply": "~0.1.1"

--- a/test/main.js
+++ b/test/main.js
@@ -129,7 +129,7 @@ describe('gulp-sass -- async compile', function() {
       // Error must include file error occurs in
       err.message.indexOf('test/scss/error.scss').should.not.equal(-1);
       // Error must include line and column error occurs on
-      err.message.indexOf('2:3').should.not.equal(-1);
+      err.message.indexOf('on line 2').should.not.equal(-1);
       done();
     });
     stream.write(errorFile);


### PR DESCRIPTION
This PR updates to the stable node-sass@^3.4.0.

It also updates the error messages to use LibSass pre-formatted errors. This means gulp-sass will now produce the exact same error messages as LibSass, node-sass, and grunt-sass.

**Before**
```
test/scss/error.scss
property "font" must be followed by a ':'
```
**After**
```
test/scss/error.scss
Error: property "font" must be followed by a ':'
        on line 2 of stdin
>>   font 'Comic Sans';
   --^
```