### PR TITLE
2.1.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass",
-  "version": "2.1.0-beta",
+  "version": "2.1.0",
   "description": "Gulp plugin for sass",
   "main": "index.js",
   "scripts": {
@@ -22,7 +22,7 @@
   },
   "dependencies": {
     "gulp-util": "^3.0",
-    "node-sass": "^3.4.0",
+    "node-sass": "^3.4.1",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"


### PR DESCRIPTION
Bump version to 2.1.0 stable

*****

```
### LibSass

Bump Node Sass to 3.4.1! 
- [3.4.0 Changelog](https://github.com/sass/node-sass/releases/tag/v3.4.0) 
- [3.4.1 Changelog](https://github.com/sass/node-sass/releases/tag/v3.4.1).
Which brings in the new super fast LibSass! 
- [3.3.0 Changelog](https://github.com/sass/libsass/releases/tag/3.3.0)
- [3.3.1 Changelog](https://github.com/sass/libsass/releases/tag/3.3.1)

### Improvements

- Use LibSass formatted error messages (@xzyfer, #374)

### Fixes

- Fix typo in documentation (@coryhouse, #366)
- Fix outdated dependencies maintaining node 0.10 support (@xzyfer, #360 #376)
- Fix test runner not cleaning up after itself (@xzyfer, #359)
- Fix empty Sass file not producing an a CSS file (@xzyfer, #352)
```