### PR TITLE
Update PostCSS deps the latest versions that support 0.10

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,11 +28,11 @@
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
-    "autoprefixer-core": "^5.0.0",
+    "autoprefixer-core": "^5.2.1",
     "eslint": "^1.6.0",
     "globule": "^0.2.0",
     "gulp": "^3.8.11",
-    "gulp-postcss": "^5.0.0",
+    "gulp-postcss": "^5.1.10",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tap": "^0.1.3",
     "mocha": "^2.2.1",


### PR DESCRIPTION
Following on from https://github.com/dlmanning/gulp-sass/pull/360.

PostCSS >= 6.0.0 has dropped support for Node 0.10. Whether we want to follow suit is beyond my pay grade here :)