### PR TITLE
Support for passing along `options.data` to `node-sass`

### DIFF
--- a/index.js
+++ b/index.js
@@ -34,8 +34,8 @@ var gulpSass = function gulpSass(options, sync) {
     }
 
 
-    opts = assign({}, options);
-    opts.data = file.contents.toString();
+    opts = assign({ 'data': '' }, options);
+    opts.data = opts.data + '\n' + file.contents.toString();
 
     // Ensure `indentedSyntax` is true if a `.sass` file
     if (path.extname(file.path) === '.sass') {

--- a/test/expected/data.css
+++ b/test/expected/data.css
@@ -1,0 +1,2 @@
+body {
+  background: red; }

--- a/test/main.js
+++ b/test/main.js
@@ -272,6 +272,24 @@ describe('gulp-sass -- async compile', function() {
       stream.write(file);
     });
   });
+
+  it('should work with options.data passed in', function(done) {
+    var sassFile = createVinyl('data.scss');
+    var stream = sass({
+      'data': '$color: red;'
+    });
+    stream.on('data', function(cssFile) {
+      should.exist(cssFile);
+      should.exist(cssFile.path);
+      should.exist(cssFile.relative);
+      should.exist(cssFile.contents);
+      String(cssFile.contents).should.equal(
+        fs.readFileSync(path.join(__dirname, 'expected/data.css'), 'utf8')
+      );
+      done();
+    });
+    stream.write(sassFile);
+  });
 });
 
 describe('gulp-sass -- sync compile', function() {

--- a/test/main.js
+++ b/test/main.js
@@ -147,7 +147,7 @@ describe('gulp-sass -- async compile', function() {
       // Error must include file error occurs in
       err.message.indexOf('test/scss/error.scss').should.not.equal(-1);
       // Error must include line and column error occurs on
-      err.message.indexOf('on line 2').should.not.equal(-1);
+      err.message.indexOf('on line 3').should.not.equal(-1);
       done();
     });
     stream.write(errorFile);

--- a/test/scss/data.scss
+++ b/test/scss/data.scss
@@ -1,0 +1,3 @@
+body {
+  background: $color;
+}


### PR DESCRIPTION
I have a use case where I need to be able to pass along the option [`data`](https://www.npmjs.com/package/node-sass#data) to node-sass. This PR fixes this.