### PR TITLE
Fixed sourcemaps filename issue ('stdin')

### DIFF
--- a/index.js
+++ b/index.js
@@ -90,7 +90,17 @@ var gulpSass = function gulpSass(options, sync) {
           }
         }
         // Replace the stdin with the original file name
-        sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
+        // sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
+
+        // Commented out line 93 and added lines 95 - 103
+        // Remove 'stdin' from souces and replace with filenames!
+        var srcs = sassMap.sources.filter(function(src) {
+          if (src.indexOf("stdin") === -1) {
+            return src;
+         }
+        });
+        sassMap.sources = srcs;
+        sassMap.sources.unshift(sassFileSrc);
         // Replace the map file with the original file name (but new extension)
         sassMap.file = gutil.replaceExtension(sassFileSrc, '.css');
         // Apply the map

--- a/index.js
+++ b/index.js
@@ -89,13 +89,9 @@ var gulpSass = function gulpSass(options, sync) {
             }
           }
         }
-        // Replace the stdin with the original file name
-        // sassMap.sources[sassMap.sources.indexOf(sassMapFile)] = sassFileSrc;
-
-        // Commented out line 93 and added lines 95 - 103
         // Remove 'stdin' from souces and replace with filenames!
         var srcs = sassMap.sources.filter(function(src) {
-          if (src.indexOf("stdin") === -1) {
+          if (src.indexOf('stdin') === -1) {
             return src;
          }
         });

--- a/index.js
+++ b/index.js
@@ -69,7 +69,7 @@ var gulpSass = function gulpSass(options, sync) {
           sassMapFile,
           sassFileSrc,
           sassFileSrcPath,
-          sourceFileIndex
+          sourceFileIndex,
           filteredSources;
 
       // Build Source Maps!

--- a/index.js
+++ b/index.js
@@ -69,7 +69,8 @@ var gulpSass = function gulpSass(options, sync) {
           sassMapFile,
           sassFileSrc,
           sassFileSrcPath,
-          sourceFileIndex;
+          sourceFileIndex
+          filteredSources;
 
       // Build Source Maps!
       if (sassObj.map) {
@@ -90,12 +91,12 @@ var gulpSass = function gulpSass(options, sync) {
           }
         }
         // Remove 'stdin' from souces and replace with filenames!
-        var srcs = sassMap.sources.filter(function(src) {
+        filteredSources = sassMap.sources.filter(function(src) {
           if (src.indexOf('stdin') === -1) {
             return src;
-         }
+          }
         });
-        sassMap.sources = srcs;
+        sassMap.sources = filteredSources;
         sassMap.sources.unshift(sassFileSrc);
         // Replace the map file with the original file name (but new extension)
         sassMap.file = gutil.replaceExtension(sassFileSrc, '.css');


### PR DESCRIPTION
Fixed the issue where sourcemaps were not displaying the correct filename, but were instead displaying 'stdin'