### PR TITLE
add relativePath property to error object for notification(s) support

### DIFF
--- a/index.js
+++ b/index.js
@@ -127,6 +127,8 @@ var gulpSass = function gulpSass(options, sync) {
       error.messageFormatted = message;
       error.message = gutil.colors.stripColor(message);
 
+      error.relativePath = relativePath;
+
       return cb(new gutil.PluginError(
           PLUGIN_NAME, error
         ));

--- a/test/main.js
+++ b/test/main.js
@@ -148,6 +148,8 @@ describe('gulp-sass -- async compile', function() {
       err.message.indexOf('test/scss/error.scss').should.not.equal(-1);
       // Error must include line and column error occurs on
       err.message.indexOf('on line 2').should.not.equal(-1);
+      // Error must include relativePath property
+      err.relativePath.should.equal('test/scss/error.scss');
       done();
     });
     stream.write(errorFile);

--- a/test/main.js
+++ b/test/main.js
@@ -379,6 +379,7 @@ describe('gulp-sass -- sync compile', function() {
 
     stream.on('error', function(err) {
       err.message.indexOf('property "font" must be followed by a \':\'').should.not.equal(-1);
+      err.relativePath.should.equal('test/scss/error.scss');
       done();
     });
     stream.write(errorFile);


### PR DESCRIPTION
This would particularly be useful for use with `gulp-notify`.

I've also added a corresponding assertions to the respective "should handle sass errors" tests.