### PR TITLE
preserve the original error message for notification(s) support

### DIFF
--- a/index.js
+++ b/index.js
@@ -125,6 +125,7 @@ var gulpSass = function gulpSass(options, sync) {
       message += error.formatted;
 
       error.messageFormatted = message;
+      error.messageOriginal = error.message;
       error.message = gutil.colors.stripColor(message);
 
       return cb(new gutil.PluginError(

--- a/test/main.js
+++ b/test/main.js
@@ -153,6 +153,20 @@ describe('gulp-sass -- async compile', function() {
     stream.write(errorFile);
   });
 
+  it('should preserve the original sass error message', function(done) {
+    var errorFile = createVinyl('error.scss');
+    var stream = sass();
+
+    stream.on('error', function(err) {
+      // Error must include original error message
+      err.messageOriginal.indexOf('property "font" must be followed by a \':\'').should.not.equal(-1);
+      // Error must not format or change the original error message
+      err.messageOriginal.indexOf('on line 2').should.equal(-1);
+      done();
+    });
+    stream.write(errorFile);
+  });
+
    it('should compile a single sass file if the file name has been changed in the stream', function(done) {
     var sassFile = createVinyl('mixins.scss');
     var stream;


### PR DESCRIPTION
This would particularly be useful for use with gulp-notify.

see #399 and #417