### PR TITLE
Pin deps to most approximately equivalent to versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -21,22 +21,22 @@
     "url": "https://github.com/dlmanning/gulp-sass/issues"
   },
   "dependencies": {
-    "gulp-util": "^3.0",
-    "node-sass": "^3.4.2",
-    "object-assign": "^4.0.1",
-    "through2": "^2.0.0",
-    "vinyl-sourcemaps-apply": "^0.2.0"
+    "gulp-util": "~3.0.0",
+    "node-sass": "~3.4.2",
+    "object-assign": "~4.0.1",
+    "through2": "~2.0.0",
+    "vinyl-sourcemaps-apply": "~0.2.0"
   },
   "devDependencies": {
-    "autoprefixer-core": "^5.2.1",
-    "eslint": "^1.6.0",
-    "globule": "^0.2.0",
-    "gulp": "^3.8.11",
-    "gulp-postcss": "^5.1.10",
-    "gulp-sourcemaps": "^1.5.2",
-    "gulp-tap": "^0.1.3",
-    "mocha": "^2.2.1",
-    "rimraf": "^2.4.3",
-    "should": "^7.1.0"
+    "autoprefixer-core": "~5.2.1",
+    "eslint": "~1.6.0",
+    "globule": "~0.2.0",
+    "gulp": "~3.8.11",
+    "gulp-postcss": "~5.1.10",
+    "gulp-sourcemaps": "~1.5.2",
+    "gulp-tap": "~0.1.3",
+    "mocha": "~2.2.1",
+    "rimraf": "~2.4.3",
+    "should": "~7.1.0"
   }
 }


### PR DESCRIPTION
This will fix #480, probably #479 and most likely any other `node-sass`-related unexpected hiccup.

Tests passing.