### PR TITLE
Bump dependency versions

### DIFF
--- a/package.json
+++ b/package.json
@@ -22,17 +22,17 @@
   },
   "dependencies": {
     "gulp-util": "^3.0",
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.7.0",
     "object-assign": "^4.0.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {
-    "autoprefixer-core": "^5.2.1",
+    "autoprefixer-core": "^6.0.1",
     "eslint": "^2.9.0",
     "globule": "^1.0.0",
     "gulp": "^3.8.11",
-    "gulp-postcss": "^5.1.10",
+    "gulp-postcss": "^6.1.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-tap": "^0.1.3",
     "mocha": "^2.2.1",


### PR DESCRIPTION
Bumps some dependencies to their latest versions. In particular, updates `node-sass` to version 3.7.0, where [these](https://github.com/gulpjs/gulp/issues/1628) [issues](https://github.com/sass/node-sass/issues/1484) are fixed. This will hopefully make `gulp-sass` print a lot less JS stack trace garbage.
