### PR TITLE
Prevent options leaking between compilations

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,7 @@
 
 var gutil = require('gulp-util');
 var through = require('through2');
-var assign = require('object-assign');
+var clonedeep = require('lodash.clonedeep');
 var path = require('path');
 var applySourceMap = require('vinyl-sourcemaps-apply');
 
@@ -34,7 +34,7 @@ var gulpSass = function gulpSass(options, sync) {
     }
 
 
-    opts = assign({}, options);
+    opts = clonedeep(options || {});
     opts.data = file.contents.toString();
 
     // we set the file path here so that libsass can correctly resolve import paths

--- a/package.json
+++ b/package.json
@@ -22,8 +22,8 @@
   },
   "dependencies": {
     "gulp-util": "^3.0",
+    "lodash.clonedeep": "^4.3.2",
     "node-sass": "^3.4.2",
-    "object-assign": "^4.0.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
Currently options are leaking between compilation runs. This is most
evident when using an array of importers. The array is shallow copied
internally, and the children of that array are wrapped by Node Sass.

When the next file is compiled the options are shallow copied once
again however this time the importer array contains the wrapped
importers not the original ones.

Instead of shallow copying with `Object.assign` this patch does a
full deep clone. Node Sass should also do this to prevent mutating
the options being passed in.

Related sass/node-sass#1168
Fixes #467 (probably)