### PR TITLE
Updates the node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.10.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
Newer OSX versions are not supported until later versions of `node-sass`.