### PR TITLE
Bump node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.12.2",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
https://github.com/sass/node-sass/issues/1484
https://github.com/sass/node-sass/issues/1504

`node-sass` prior to version `3.7.0`  fails to compile with node v6