### PR TITLE
Update node-sass

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^3.4.2",
+    "node-sass": "^3.14.0-0",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
Previous versions of `node-sass` throw an invalid `Duplicate key #{key} in map` error, even when a map does not contain duplicate keys. This only happens in some edge cases and has to do with how `libsass` hashes maps. This issue has been previously documented in https://github.com/sass/node-sass/issues/1072, and was thought to be fixed.

The latest version of `node-sass` does not throw this error incorrectly anymore.