### PR TITLE
Update node-sass to 4.5.0 to support Node 6

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 # Gulp Sass Changelog
 
+## v3.1.1
+**March 9, 2017**
+
+* **Change** :arrow_up: Bump to Node Sass 4.5.0
+
 ## v2.1.0-beta
 **September 21, 2015**
 

--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^4.2.0",
+    "node-sass": "^4.5.0",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
Update the Node Sass version to the latest 4.5.0 so that it can compile on Linux 64-bit. 

Fixes: https://github.com/dlmanning/gulp-sass/issues/594