### PR TITLE
4.0.0. release

### DIFF
--- a/README.md
+++ b/README.md
@@ -52,7 +52,7 @@ gulp.task('sass:watch', function () {
 
 ## Options
 
-Pass in options just like you would for [`node-sass`](https://github.com/sass/node-sass#options); they will be passed along just as if you were using `node-sass`. Except for the `data` option which is used by gulp-sass internally. Using the `file` option is also unsupported and results in undefined behaviour that may change without notice.  
+Pass in options just like you would for [`node-sass`](https://github.com/sass/node-sass#options); they will be passed along just as if you were using `node-sass`. Except for the `file` option which is unsupported and results in undefined behaviour that may change without notice.  
 
 For example:
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var gulpSass = function gulpSass(options, sync) {
 
 
     opts = clonedeep(options || {});
-    if(opts.data === void 0) {
+    if (opts.data === void 0) {
       opts.data = file.contents.toString();
     }
     else {

--- a/index.js
+++ b/index.js
@@ -35,8 +35,13 @@ var gulpSass = function gulpSass(options, sync) {
 
 
     opts = clonedeep(options || {});
-    opts.data = opts.data + file.contents.toString();
-
+    if(opts.data === void 0) {
+      opts.data = file.contents.toString();
+    }
+    else {
+      opts.data = opts.data + file.contents.toString();
+    }
+    
     // we set the file path here so that libsass can correctly resolve import paths
     opts.file = file.path;
 

--- a/index.js
+++ b/index.js
@@ -35,7 +35,7 @@ var gulpSass = function gulpSass(options, sync) {
 
 
     opts = clonedeep(options || {});
-    opts.data = file.contents.toString();
+    opts.data = opts.data + file.contents.toString();
 
     // we set the file path here so that libsass can correctly resolve import paths
     opts.file = file.path;
@@ -49,6 +49,9 @@ var gulpSass = function gulpSass(options, sync) {
     if (opts.includePaths) {
       if (typeof opts.includePaths === 'string') {
         opts.includePaths = [opts.includePaths];
+      }
+      else {
+        throw new Error('options.includePaths expected to be a string, ' + typeof opts.includePaths + ' given.');
       }
     }
     else {

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Gulp plugin for sass",
   "main": "index.js",
   "scripts": {


### PR DESCRIPTION
options.data works and options.includePaths throws error on invalid data type given.

New version released due to BC break.