### PR TITLE
Updated node-sass version

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^4.2.0",
+    "node-sass": "^4.5.3",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
Newest version is necessary for compatibility with node 8.

Resolves #621 