### PR TITLE
Add documentation for synchronous code options

### DIFF
--- a/README.md
+++ b/README.md
@@ -64,6 +64,16 @@ gulp.task('sass', function () {
 });
 ```
 
+Or this for synchronous code:
+
+```javascript
+gulp.task('sass', function () {
+ return gulp.src('./sass/**/*.scss')
+   .pipe(sass.sync({outputStyle: 'compressed'}).on('error', sass.logError))
+   .pipe(gulp.dest('./css'));
+});
+```
+
 ## Source Maps
 
 `gulp-sass` can be used in tandem with [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) to generate source maps for the Sass to CSS compilation. You will need to initialize [gulp-sourcemaps](https://github.com/floridoo/gulp-sourcemaps) prior to running `gulp-sass` and write the source maps after.


### PR DESCRIPTION
It's not clearly documented how to add options to sass.sync, and this is implemented inconsistently across other code infrastructures, so it's not safe to assume whether it's `sass(options).sync()` or `sass.sync(options)` please accept the pull request if the proposed documentation is correct, or otherwise accept it anyways and provide a follow up merge as an update fix.