### PR TITLE
Update node-sass for Node v9.x support

### DIFF
--- a/package.json
+++ b/package.json
@@ -23,7 +23,7 @@
   "dependencies": {
     "gulp-util": "^3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^4.2.0",
+    "node-sass": "^4.6.1",
     "through2": "^2.0.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },


### PR DESCRIPTION
The current version of node-sass does not support Node v9.x.

node-sass 4.6.1 does support Node v9.x.

https://github.com/sass/node-sass/issues/2129