### PR TITLE
Require Node 4+

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,3 +13,7 @@ results
 
 npm-debug.log
 node_modules
+yarn.lock
+package-lock.json
+
+.idea

--- a/.travis.yml
+++ b/.travis.yml
@@ -1,6 +1,7 @@
 language: node_js
 node_js:
-  - "0.10"
-  - node
-  - iojs
+  - "lts/argon"
+  - "lts/boron"
+  - "lts/carbon"
+  - "node"
 sudo: false

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,30 @@
 # Gulp Sass Changelog
 
+## v4.0.0
+**Upcoming**
+
+* **Breaking change** Drop support for Node for versions that reached end of life (`< 4`).
+
+## v3.1.0
+**January 9, 2017**
+
+* **Change** ⬆️ Bump to Node Sass 4.2.0
+
+## v3.0.0
+**December 10, 2016**
+
+* **Breaking change** ⬆️ Bump to Node Sass 4.0.0
+
+## v2.3.2
+**June 15, 2016**
+
+* **Fix** Prevent options from leaking between compilations
+* **Chore** Update dependencies
+
+## v2.1.0 to v2.3.1
+
+(missing, please open a PR if you wish to fill the gap)
+
 ## v2.1.0-beta
 **September 21, 2015**
 

--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "gulp-sass",
-  "version": "3.1.0",
+  "version": "4.0.0",
   "description": "Gulp plugin for sass",
   "main": "index.js",
   "scripts": {
@@ -19,6 +19,9 @@
   "license": "MIT",
   "bugs": {
     "url": "https://github.com/dlmanning/gulp-sass/issues"
+  },
+  "engines": {
+    "node": ">=4.0.0"
   },
   "dependencies": {
     "gulp-util": "^3.0",


### PR DESCRIPTION
This commit drops support for Node versions that reached EOL.

Closes #648
