### PR TITLE
gulp-util is deprecated

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,10 +1,13 @@
 'use strict';
 
-var gutil = require('gulp-util');
 var through = require('through2');
 var clonedeep = require('lodash.clonedeep');
 var path = require('path');
 var applySourceMap = require('vinyl-sourcemaps-apply');
+var PluginError = require('plugin-error');
+var replaceExt = require('replace-ext');
+var colors = require('ansi-colors');
+var stripColor = require('strip-color');
 
 var PLUGIN_NAME = 'gulp-sass';
 
@@ -23,13 +26,13 @@ var gulpSass = function gulpSass(options, sync) {
       return cb(null, file);
     }
     if (file.isStream()) {
-      return cb(new gutil.PluginError(PLUGIN_NAME, 'Streaming not supported'));
+      return cb(new PluginError(PLUGIN_NAME, 'Streaming not supported'));
     }
     if (path.basename(file.path).indexOf('_') === 0) {
       return cb();
     }
     if (!file.contents.length) {
-      file.path = gutil.replaceExtension(file.path, '.css');
+      file.path = replaceExt(file.path, '.css');
       return cb(null, file);
     }
 
@@ -100,13 +103,13 @@ var gulpSass = function gulpSass(options, sync) {
         });
 
         // Replace the map file with the original file name (but new extension)
-        sassMap.file = gutil.replaceExtension(sassFileSrc, '.css');
+        sassMap.file = replaceExt(sassFileSrc, '.css');
         // Apply the map
         applySourceMap(file, sassMap);
       }
 
       file.contents = sassObj.css;
-      file.path = gutil.replaceExtension(file.path, '.css');
+      file.path = replaceExt(file.path, '.css');
 
       cb(null, file);
     };
@@ -122,18 +125,16 @@ var gulpSass = function gulpSass(options, sync) {
       filePath = filePath ? filePath : file.path;
       relativePath = path.relative(process.cwd(), filePath);
 
-      message += gutil.colors.underline(relativePath) + '\n';
+      message += colors.underline(relativePath) + '\n';
       message += error.formatted;
 
       error.messageFormatted = message;
       error.messageOriginal = error.message;
-      error.message = gutil.colors.stripColor(message);
+      error.message = stripColor(message);
 
       error.relativePath = relativePath;
 
-      return cb(new gutil.PluginError(
-          PLUGIN_NAME, error
-        ));
+      return cb(new PluginError(PLUGIN_NAME, error));
     };
 
     if (sync !== true) {
@@ -176,7 +177,7 @@ gulpSass.sync = function sync(options) {
 // Log errors nicely
 //////////////////////////////
 gulpSass.logError = function logError(error) {
-  var message = new gutil.PluginError('sass', error.messageFormatted).toString();
+  var message = new PluginError('sass', error.messageFormatted).toString();
   process.stderr.write(message + '\n');
   this.emit('end');
 };

--- a/package.json
+++ b/package.json
@@ -21,10 +21,14 @@
     "url": "https://github.com/dlmanning/gulp-sass/issues"
   },
   "dependencies": {
-    "gulp-util": "^3.0",
+    "ansi-colors": "^1.1.0",
     "lodash.clonedeep": "^4.3.2",
     "node-sass": "^4.8.3",
+    "plugin-error": "^1.0.1",
+    "replace-ext": "^1.0.0",
+    "strip-color": "^0.1.0",
     "through2": "^2.0.0",
+    "vinyl": "^2.1.0",
     "vinyl-sourcemaps-apply": "^0.2.0"
   },
   "devDependencies": {

--- a/test/main.js
+++ b/test/main.js
@@ -1,7 +1,7 @@
 'use strict';
 
 var should = require('should');
-var gutil = require('gulp-util');
+var Vinyl = require('vinyl');
 var path = require('path');
 var fs = require('fs');
 var sass = require('../index');
@@ -17,7 +17,7 @@ var createVinyl = function createVinyl(filename, contents) {
   var base = path.join(__dirname, 'scss');
   var filePath = path.join(base, filename);
 
-  return new gutil.File({
+  return new Vinyl({
     'cwd': __dirname,
     'base': base,
     'path': filePath,


### PR DESCRIPTION
Per [The Problem with gulp-util](https://medium.com/gulpjs/gulp-util-ca3b1f9f9ac5) this replaces all the gulp-util functions with other packages.