### PR TITLE
Adding 'use strict' to use let, const, class

### DIFF
--- a/index.js
+++ b/index.js
@@ -1,3 +1,5 @@
+'use strict';
+
 const chalk = require('chalk');
 const PluginError = require('plugin-error');
 const replaceExtension = require('replace-ext');


### PR DESCRIPTION
without 'use strict' gulp node throwing an error

/home/anyms/Desktop/Desktop/Github/codebreak/chaiui/node_modules/gulp-sass/index.js:66
    let sassMap;
    ^^^

SyntaxError: Block-scoped declarations (let, const, function, class) not yet supported outside strict mode
    at exports.runInThisContext (vm.js:53:16)
    at Module._compile (module.js:374:25)
    at Object.Module._extensions..js (module.js:417:10)
    at Module.load (module.js:344:32)
    at Function.Module._load (module.js:301:12)
    at Module.require (module.js:354:17)
    at require (internal/module.js:12:17)
    at Object.<anonymous> (/home/anyms/Desktop/Desktop/Github/codebreak/chaiui/gulpfile.js:8:22)
    at Module._compile (module.js:410:26)
    at Object.Module._extensions..js (module.js:417:10)