### PR TITLE
set modified time when modifying file

### DIFF
--- a/index.js
+++ b/index.js
@@ -98,7 +98,11 @@ const gulpSass = (options, sync) => through.obj((file, enc, cb) => { // eslint-d
 
     file.contents = sassObj.css; // eslint-disable-line no-param-reassign
     file.path = replaceExtension(file.path, '.css'); // eslint-disable-line no-param-reassign
-
+    
+    // Since file is modified now, we need to update the times
+    let date = new Date();
+    file.stat.mtime = date; // eslint-disable-line no-param-reassign
+    
     cb(null, file);
   };
 


### PR DESCRIPTION
Gulp plugins that create/modify output files are responsible for updating file modified timestamps as of Gulp 4 https://github.com/gulpjs/gulp/issues/2193#issuecomment-399168738

This change simply updates the file stat appropriately.

Fixes #706