### PR TITLE
Bump node-sass@^4.9.3

### DIFF
--- a/package.json
+++ b/package.json
@@ -26,7 +26,7 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "lodash.clonedeep": "^4.3.2",
-    "node-sass": "^4.8.3",
+    "node-sass": "^4.9.3",
     "plugin-error": "^1.0.1",
     "replace-ext": "^1.0.0",
     "strip-ansi": "^4.0.0",


### PR DESCRIPTION
Bump node-sass to the latest stable release (4.9.3)

To add support for node 10, which was added here https://github.com/sass/node-sass/pull/2349

