### PR TITLE
Migrate to the lodash package

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const PluginError = require('plugin-error');
 const replaceExtension = require('replace-ext');
 const stripAnsi = require('strip-ansi');
 const through = require('through2');
-const clonedeep = require('lodash.clonedeep');
+const clonedeep = require('lodash/cloneDeep');
 const path = require('path');
 const applySourceMap = require('vinyl-sourcemaps-apply');
 

--- a/package.json
+++ b/package.json
@@ -25,7 +25,7 @@
   },
   "dependencies": {
     "chalk": "^2.3.0",
-    "lodash.clonedeep": "^4.3.2",
+    "lodash": "^4.17.11",
     "node-sass": "^4.8.3",
     "plugin-error": "^1.0.1",
     "replace-ext": "^1.0.0",


### PR DESCRIPTION
The modularized lodash packages are unmaintained since 2 years, lagging a lot behind the main lodash package. Partial imports of lodash are the preferred way.
See https://github.com/lodash/lodash/issues/2969