### PR TITLE
Lazily require node-sass

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,8 +13,9 @@ Only [Active LTS and Current releases][1] are supported.
 # Install
 
 ```
-npm install node-sass gulp-sass --save-dev
+npm install gulp-sass --save-dev
 ```
+You must also install either `node-sass` or `sass`.
 
 # Basic Usage
 
@@ -60,7 +61,8 @@ gulp.task('sass:watch', function () {
 });
 ```
 
-You can choose whether to use [Dart Sass][] or [Node Sass][] by setting the `sass.compiler` property. Node Sass will be used by default, but it's strongly recommended that you set it explicitly for forwards-compatibility in case the default ever changes.
+## Compiler implementation
+You can choose whether to use [Dart Sass][] or [Node Sass][] by setting the `sass.compiler` property. Node Sass will be used by default, but it's strongly recommended that you set it explicitly for forwards-compatibility in case the default ever changes. For the default behavior to work the `node-sass` package has to be installed.
 
 [Dart Sass]: http://sass-lang.com/dart-sass
 [Node Sass]: https://github.com/sass/node-sass

--- a/index.js
+++ b/index.js
@@ -118,6 +118,9 @@ const gulpSass = (options, sync) => through.obj((file, enc, cb) => { // eslint-d
     return cb(new PluginError(PLUGIN_NAME, error));
   };
 
+  // eslint-disable-next-line global-require, import/no-extraneous-dependencies
+  const compiler = gulpSass.compiler || require('node-sass');
+
   if (sync !== true) {
     //////////////////////////////
     // Async Sass render
@@ -129,13 +132,13 @@ const gulpSass = (options, sync) => through.obj((file, enc, cb) => { // eslint-d
       filePush(obj);
     };
 
-    gulpSass.compiler.render(opts, callback);
+    compiler.render(opts, callback);
   } else {
     //////////////////////////////
     // Sync Sass render
     //////////////////////////////
     try {
-      filePush(gulpSass.compiler.renderSync(opts));
+      filePush(compiler.renderSync(opts));
     } catch (error) {
       return errorM(error);
     }
@@ -157,8 +160,8 @@ gulpSass.logError = function logError(error) {
 };
 
 //////////////////////////////
-// Store compiler in a prop
+// Store compiler in a prop (node-sass is dynamically required if needed)
 //////////////////////////////
-gulpSass.compiler = require('node-sass');
+gulpSass.compiler = null;
 
 module.exports = gulpSass;

--- a/package.json
+++ b/package.json
@@ -26,7 +26,6 @@
   "dependencies": {
     "chalk": "^2.3.0",
     "lodash": "^4.17.11",
-    "node-sass": "^4.8.3",
     "plugin-error": "^1.0.1",
     "replace-ext": "^1.0.0",
     "strip-ansi": "^4.0.0",
@@ -44,6 +43,7 @@
     "gulp-sourcemaps": "^2.6.4",
     "gulp-tap": "^0.1.3",
     "mocha": "^5.0.4",
+    "node-sass": "^4.12.0",
     "rimraf": "^2.4.3",
     "should": "^13.2.1",
     "vinyl": "^2.1.0"


### PR DESCRIPTION
Closes #747.

Implementation of #747 for your convenience.
I'm technically in violation of the contributor guidelines by opening this PR without prior approval, but I need this functionality *right now* and I want to use my fork in the meantime.

I'm not sure how I should update the changelog, should I add a new version "heading"?