### PR TITLE
Require `node-sass` on first access to gulpSass.compiler

### DIFF
--- a/index.js
+++ b/index.js
@@ -167,7 +167,7 @@ Object.defineProperty(gulpSass, 'compiler', {
   writeable: true,
   configurable: true,
   enumerable: true,
-  get: function () {
+  get: function getCompiler() {
     delete gulpSass.compiler;
     return gulpSass.compiler = require('node-sass');
   }

--- a/index.js
+++ b/index.js
@@ -163,6 +163,14 @@ gulpSass.logError = function logError(error) {
 //////////////////////////////
 // Store compiler in a prop
 //////////////////////////////
-gulpSass.compiler = require('node-sass');
+Object.defineProperty(gulpSass, 'compiler', {
+  writeable: true,
+  configurable: true,
+  enumerable: true,
+  get: function () {
+    delete gulpSass.compiler;
+    return gulpSass.compiler = require('node-sass');
+  }
+});
 
 module.exports = gulpSass;


### PR DESCRIPTION
I want to use this plugin with `sass`, not `node-sass`, but the line with `require('node-sass')` throws an error, before I have the chance to `gulpSass.compiler = require('sass');`.
The error message says:
`Node Sass could not find a binding for your current environment: Linux 64-bit with Node.js 14.x`

This PR should fix the issue transparently.

I would also prefer not to include the `node-sass` lib as a dependency, maybe a peer-dependency.