### PR TITLE
Pass along sass's `stats` object

### DIFF
--- a/index.js
+++ b/index.js
@@ -103,6 +103,9 @@ const gulpSass = (options, sync) => transfob((file, enc, cb) => { // eslint-disa
       file.stat.atime = file.stat.mtime = file.stat.ctime = new Date(); // eslint-disable-line
     }
 
+    // Pass along some potentially useful data.
+    file.sassStats = sassObj.stats;
+
     cb(null, file);
   };
 


### PR DESCRIPTION
The `stats` object that's returned from the sass compiler contains some interesting info, particularly `includedFiles` which can be used to develop smarter watchers. Related to #279, fixed #428