### PR TITLE
Replace lodash with the lodash.clonedeep package

### DIFF
--- a/index.js
+++ b/index.js
@@ -3,7 +3,7 @@ const PluginError = require('plugin-error');
 const replaceExtension = require('replace-ext');
 const stripAnsi = require('strip-ansi');
 const transfob = require('transfob');
-const clonedeep = require('lodash/cloneDeep');
+const clonedeep = require('lodash.clonedeep');
 const path = require('path');
 const applySourceMap = require('vinyl-sourcemaps-apply');
 

--- a/package-lock.json
+++ b/package-lock.json
@@ -3385,13 +3385,13 @@
     "lodash": {
       "version": "4.17.21",
       "resolved": "https://registry.npmjs.org/lodash/-/lodash-4.17.21.tgz",
-      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg=="
+      "integrity": "sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==",
+      "dev": true
     },
     "lodash.clonedeep": {
       "version": "4.5.0",
       "resolved": "https://registry.npmjs.org/lodash.clonedeep/-/lodash.clonedeep-4.5.0.tgz",
-      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8=",
-      "dev": true
+      "integrity": "sha1-4j8/nE+Pvd6HJSnBBxhXoIblzO8="
     },
     "lodash.merge": {
       "version": "4.6.2",

--- a/package.json
+++ b/package.json
@@ -28,7 +28,7 @@
   ],
   "dependencies": {
     "chalk": "^4.1.2",
-    "lodash": "^4.17.21",
+    "lodash.clonedeep": "^4.5.0",
     "plugin-error": "^1.0.1",
     "replace-ext": "^2.0.0",
     "strip-ansi": "^6.0.1",


### PR DESCRIPTION
Notes:

1. lodash isn't in any of the current dependencies' deps
2. I'm unsure if the individual packages are still maintained, though. Alternatively, we could find another package.

https://packagephobia.com/result?p=lodash%2Clodash.clonedeep