### PR TITLE
Remove strip-ansi dependency

### DIFF
--- a/index.js
+++ b/index.js
@@ -2,7 +2,6 @@ const path = require('path');
 const chalk = require('chalk');
 const PluginError = require('plugin-error');
 const replaceExtension = require('replace-ext');
-const stripAnsi = require('strip-ansi');
 const transfob = require('transfob');
 const clonedeep = require('lodash.clonedeep');
 const applySourceMap = require('vinyl-sourcemaps-apply');
@@ -112,11 +111,12 @@ const gulpSass = (options, sync) => transfob((file, enc, cb) => { // eslint-disa
   const errorM = (error) => {
     const filePath = (error.file === 'stdin' ? file.path : error.file) || file.path;
     const relativePath = path.relative(process.cwd(), filePath);
-    const message = [chalk.underline(relativePath), error.formatted].join('\n');
+    const message = `${relativePath}\n${error.formatted}`;
+    const messageFormatted = `${chalk.underline(relativePath)}\n${error.formatted}`;
 
-    error.messageFormatted = message; // eslint-disable-line no-param-reassign
+    error.messageFormatted = messageFormatted; // eslint-disable-line no-param-reassign
     error.messageOriginal = error.message; // eslint-disable-line no-param-reassign
-    error.message = stripAnsi(message); // eslint-disable-line no-param-reassign
+    error.message = message; // eslint-disable-line no-param-reassign
     error.relativePath = relativePath; // eslint-disable-line no-param-reassign
 
     return cb(new PluginError(PLUGIN_NAME, error));

--- a/package-lock.json
+++ b/package-lock.json
@@ -270,7 +270,8 @@
     "ansi-regex": {
       "version": "5.0.1",
       "resolved": "https://registry.npmjs.org/ansi-regex/-/ansi-regex-5.0.1.tgz",
-      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ=="
+      "integrity": "sha512-quJQXlTSUGL2LH9SUXo8VwsY4soanhgo6LNSm84E1LBcE8s3O0wpdiRzyR9z/ZZJMlMWv37qOOb9pdJlMUEKFQ==",
+      "dev": true
     },
     "ansi-styles": {
       "version": "4.3.0",
@@ -5755,6 +5756,7 @@
       "version": "6.0.1",
       "resolved": "https://registry.npmjs.org/strip-ansi/-/strip-ansi-6.0.1.tgz",
       "integrity": "sha512-Y38VPSHcqkFrCpFnQ9vuSXmquuv5oXOKpGeT6aGrr3o3Gc9AlVa6JBfUSOCnbxGGZF+/0ooI7KrPuUSztUdU5A==",
+      "dev": true,
       "requires": {
         "ansi-regex": "^5.0.1"
       }

--- a/package.json
+++ b/package.json
@@ -35,7 +35,6 @@
     "lodash.clonedeep": "^4.5.0",
     "plugin-error": "^1.0.1",
     "replace-ext": "^2.0.0",
-    "strip-ansi": "^6.0.1",
     "transfob": "^1.0.0",
     "vinyl-sourcemaps-apply": "^0.2.1"
   },


### PR DESCRIPTION
This one needs close review, but I think that strip-ansi was just stripping chalk's ANSI escapes. Now, the question is if the sass compilers add ANSI escapes.

There's a little duplication, but I couldn't find a way to simplify this. Any ideas welcome!