### PR TITLE
Pass along sass's `stats` object - followup

### DIFF
--- a/index.js
+++ b/index.js
@@ -62,6 +62,9 @@ const filePush = (file, sassObject, callback) => {
     file.stat.atime = file.stat.mtime = file.stat.ctime = new Date();
   }
 
+  // Pass along some potentially useful data.
+  file.sassStats = sassObject.stats;
+
   callback(null, file);
 };
 

--- a/index.js
+++ b/index.js
@@ -108,6 +108,7 @@ const gulpSass = (options, sync) => {
 
     if (!file.contents.length) {
       file.path = replaceExtension(file.path, '.css');
+      file.sassStats = null;
       callback(null, file);
       return;
     }

--- a/test/main.js
+++ b/test/main.js
@@ -75,6 +75,7 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.equal(cssFile.sassStats, null);
       assert.equal(path.basename(cssFile.path), 'empty.css');
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'empty.css'), 'utf8');
@@ -92,9 +93,11 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'mixins.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
       done();
     });
     stream.write(sassFile);
@@ -114,12 +117,15 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
+
       if (cssFile.path.includes('variables')) {
         expectedPath = path.join(expectedTestsPath, 'variables.css');
       }
 
       const actual = fs.readFileSync(path.join(__dirname, expectedPath), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
 
       mustSee -= 1;
       if (mustSee <= 0) {
@@ -140,9 +146,11 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'inheritance.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 3);
       done();
     });
     stream.write(sassFile);
@@ -205,9 +213,11 @@ describe('gulp-sass -- async compile', () => {
       assert.equal(cssFile.path.split(path.sep).pop(), 'mixin--changed.css');
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'mixins.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
       done();
     });
     stream.write(sassFile);
@@ -224,9 +234,11 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'mixins.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), `/* Added Dynamically */\n${normaliseEOL(actual)}`);
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
       done();
     });
     stream.write(sassFile);
@@ -268,9 +280,11 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'indent.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
       done();
     });
     stream.write(sassFile);
@@ -290,12 +304,14 @@ describe('gulp-sass -- async compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
       if (cssFile.path.includes('indent')) {
         expectedPath = path.join(expectedTestsPath, 'indent.css');
       }
 
       const actual = fs.readFileSync(path.join(__dirname, expectedPath), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
 
       mustSee -= 1;
       if (mustSee <= 0) {
@@ -347,9 +363,11 @@ describe('gulp-sass -- sync compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'mixins.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
       done();
     });
     stream.write(sassFile);
@@ -369,6 +387,7 @@ describe('gulp-sass -- sync compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       if (cssFile.path.includes('variables')) {
         expectedPath = path.join(expectedTestsPath, 'variables.css');
@@ -376,6 +395,7 @@ describe('gulp-sass -- sync compile', () => {
 
       const actual = normaliseEOL(fs.readFileSync(path.join(__dirname, expectedPath), 'utf8'));
       assert.equal(String(normaliseEOL(cssFile.contents)), actual);
+      assert.equal(cssFile.sassStats.includedFiles.length, 1);
 
       mustSee -= 1;
       if (mustSee <= 0) {
@@ -397,9 +417,11 @@ describe('gulp-sass -- sync compile', () => {
       assert.ok(cssFile.path);
       assert.ok(cssFile.relative);
       assert.ok(cssFile.contents);
+      assert.ok(cssFile.sassStats);
 
       const actual = fs.readFileSync(path.join(__dirname, expectedTestsPath, 'inheritance.css'), 'utf8');
       assert.equal(String(normaliseEOL(cssFile.contents)), normaliseEOL(actual));
+      assert.equal(cssFile.sassStats.includedFiles.length, 3);
       done();
     });
     stream.write(sassFile);


### PR DESCRIPTION
This is a followup PR to https://github.com/dlmanning/gulp-sass/pull/808.

I’ve updated it with latest changes and added tests.