### PR TITLE
Fix typo in Migrating to version 5

### DIFF
--- a/README.md
+++ b/README.md
@@ -158,7 +158,7 @@ Then, you must explicitly set that compiler in your gulpfille. Instead of settin
 These changes look something like this:
 
 ```diff
-- const sass = require('gulp-sass'));
+- const sass = require('gulp-sass');
 - const compiler = require('sass');
 - sass.compiler = compiler;
 + const sass = require('gulp-sass')(require('sass'));


### PR DESCRIPTION
In README.md at Migrating to version 5: Change `require('gulp-sass'));` to `require('gulp-sass');`
Checked for similar typos.